### PR TITLE
feat: Added custom button to create Project Template from Compliance Sub Category

### DIFF
--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -105,13 +105,11 @@ doctype_js = {
 # ---------------
 # Hook on document methods and events
 
-# doc_events = {
-#	"*": {
-#		"on_update": "method",
-#		"on_cancel": "method",
-#		"on_trash": "method"
-#	}
-# }
+doc_events = {
+	"Project Template": {
+		"after_insert": "one_compliance.one_compliance.doc_events.project_template.update_project_template",
+	}
+}
 
 # Scheduled Tasks
 # ---------------

--- a/one_compliance/one_compliance/doc_events/project_template.py
+++ b/one_compliance/one_compliance/doc_events/project_template.py
@@ -1,0 +1,10 @@
+import frappe
+from frappe.model.document import Document
+from frappe.model.mapper import *
+
+
+@frappe.whitelist()
+def update_project_template(doc, method=None):
+    ''' Method to set project template in Compliance Sub Category '''
+    frappe.db.set_value('Compliance Sub Category', doc.compliance_sub_category, 'project_template', doc.name)
+    frappe.db.commit()

--- a/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.js
+++ b/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.js
@@ -2,7 +2,16 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Compliance Sub Category', {
-	// refresh: function(frm) {
+	refresh: function(frm) {
+    if(!frm.is_new() && !frm.doc.project_template){
+			//custom button to create project template and route to  project template doctype
+     frm.add_custom_button('Create Project Template', () =>{
+       frappe.model.open_mapped_doc({
+         method: 'one_compliance.one_compliance.doctype.compliance_sub_category.compliance_sub_category.create_project_template_custom_button',
+         frm: cur_frm
+       });
+     });
+    }
+	},
 
-	// }
 });

--- a/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.json
+++ b/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.json
@@ -12,8 +12,7 @@
   "sub_category",
   "project_template",
   "column_break_06mwn",
-  "start_date",
-  "end_date",
+  "maximum_duration",
   "allow_repeat",
   "repeat_on"
  ],
@@ -31,13 +30,15 @@
    "fieldname": "sub_category",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": " Sub Category"
+   "label": " Sub Category",
+   "reqd": 1
   },
   {
    "fieldname": "project_template",
    "fieldtype": "Link",
    "label": "Project Template",
-   "options": "Project Template"
+   "options": "Project Template",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_06mwn",
@@ -49,28 +50,23 @@
    "fieldtype": "Select",
    "label": "Repeat On",
    "mandatory_depends_on": "eval:doc.allow_repeat == 1",
-   "options": "\nMonthly\nQuarterly\nHalfyearly\nYearly"
-  },
-  {
-   "fieldname": "start_date",
-   "fieldtype": "Date",
-   "label": "Start Date"
-  },
-  {
-   "fieldname": "end_date",
-   "fieldtype": "Date",
-   "label": "End date"
+   "options": "\nMonthly\nQuarterly\nHalf yearly\nyearly"
   },
   {
    "default": "0",
    "fieldname": "allow_repeat",
    "fieldtype": "Check",
    "label": "Allow Repeat"
+  },
+  {
+   "fieldname": "maximum_duration",
+   "fieldtype": "Int",
+   "label": "Maximum Duration"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-03-13 12:45:25.288367",
+ "modified": "2023-03-15 10:54:25.605230",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Compliance Sub Category",
@@ -90,7 +86,6 @@
    "write": 1
   }
  ],
- "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.py
+++ b/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.py
@@ -1,8 +1,25 @@
 # Copyright (c) 2023, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe.model.mapper import *
 
 class ComplianceSubCategory(Document):
 	pass
+
+@frappe.whitelist()
+def create_project_template_custom_button(source_name, target_doc = None):
+	''' Method to get project template for custom button using mapdoc '''
+	def set_missing_values(source, target):
+		target.compliance_category= source.compliance_category
+		target.compliance_sub_category = source.name
+	doc = get_mapped_doc(
+		'Compliance Sub Category',
+		source_name,
+		{
+		'Compliance Sub Category': {
+		'doctype': 'Project Template',
+        },
+		}, target_doc, set_missing_values)
+	return doc


### PR DESCRIPTION

## Feature description
-> Removed start date and end date from compliance sub category and added maximum duration field
-> Added a new custom button for creating project template
-> Set the project_template field read-only and set the created project template into the field
-> Disabled the custom button after creating the project template 



## Is there any existing behavior change of other features due to this code change? 
   - No
## Was this feature tested on the browsers?
  - Chrome : yes


## Output screenshots 
sub category
![image](https://user-images.githubusercontent.com/115983752/225219398-7612d1e0-e0f9-4502-8ec4-2615080edead.png)

Sub category after save , added create project template button
![image](https://user-images.githubusercontent.com/115983752/225219557-9e2199fd-88a2-48de-a0c0-0fb2e2b31a7f.png)

create project template
![image](https://user-images.githubusercontent.com/115983752/225219711-6e185f28-de65-4719-8fb8-6b2ea74ea841.png)

project template  is set to the field project template and button in invisible
![image](https://user-images.githubusercontent.com/115983752/225219773-0f086836-99b9-4637-9055-0a11282c6d64.png)
