### PR TITLE
feat: Created a Checkbox in Outward doctype and set visible only to Compliance Manager

### DIFF
--- a/one_compliance/fixtures/custom_docperm.json
+++ b/one_compliance/fixtures/custom_docperm.json
@@ -498,5 +498,30 @@
   "share": 1,
   "submit": 1,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 1,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 1,
+  "modified": "2023-03-17 11:16:29.210060",
+  "name": "6819fd1eb4",
+  "parent": "Outward Register",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 0,
+  "role": "Compliance Manager",
+  "select": 1,
+  "set_user_permissions": 0,
+  "share": 1,
+  "submit": 1,
+  "write": 1
  }
 ]

--- a/one_compliance/one_compliance/doctype/outward_register/outward_register.js
+++ b/one_compliance/one_compliance/doctype/outward_register/outward_register.js
@@ -3,8 +3,18 @@
 
 frappe.ui.form.on('Outward Register', {
 	refresh: function(frm) {
-    if(frm.is_new()){
+    if(frm.is_new()) {
+			//Set the return_by default as session user
       frm.set_value("returned_by",frappe.session.user)
     }
+
+		let roles = frappe.user_roles;
+		if(roles.includes('Compliance Manager')) {
+			// Set edit Return date and time checkbox visible for compliance manager
+			frm.set_df_property('edit_return_date_and_time','hidden',0);
+		}
+		else {
+			frm.set_df_property('edit_return_date_and_time','hidden',1);
+		}
 	}
 });

--- a/one_compliance/one_compliance/doctype/outward_register/outward_register.json
+++ b/one_compliance/one_compliance/doctype/outward_register/outward_register.json
@@ -20,6 +20,7 @@
   "column_break_b6il8",
   "returned_date",
   "returned_time",
+  "edit_return_date_and_time",
   "status",
   "customer",
   "returned_through",
@@ -179,23 +180,33 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Returned Date"
+   "label": "Returned Date",
+   "read_only_depends_on": "eval:doc.edit_return_date_and_time == 0",
+   "reqd": 1
   },
   {
    "default": "Now",
    "fieldname": "returned_time",
    "fieldtype": "Time",
-   "label": "Returned Time"
+   "label": "Returned Time",
+   "read_only_depends_on": "eval:doc.edit_return_date_and_time == 0",
+   "reqd": 1
   },
   {
    "fieldname": "section_break_pmpst",
    "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "edit_return_date_and_time",
+   "fieldtype": "Check",
+   "label": "Edit Return Date and Time"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-03-16 15:31:56.953441",
+ "modified": "2023-03-17 11:08:29.665582",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Outward Register",


### PR DESCRIPTION
## Feature description
-> Created a Checkbox in Outward doctype to edit the Return date and Time and set visible only to Compliance Manager




## Is there any existing behavior change of other features due to this code change?
  - No
## Was this feature tested on the browsers?
  - Chrome : Yes

## Output screenshots 
-> Administrator view
![image](https://user-images.githubusercontent.com/115983752/225824968-3b567406-0e25-4077-b9d7-be0069214f35.png)

-> Director view
![image](https://user-images.githubusercontent.com/115983752/225825019-d0d1cf1a-acc9-49e9-8413-da345e33da30.png)
