### PR TITLE
fix: Set multi select for document and general register type

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.json
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.json
@@ -21,10 +21,6 @@
   "compliance_category",
   "compliance_category_details",
   "total",
-  "signatures_section",
-  "customer_signature",
-  "column_break_qxw6c",
-  "authority_signature",
   "payments_details_tab",
   "bank_details_section",
   "bank_name",
@@ -37,6 +33,10 @@
   "default_payment_terms_template",
   "terms_and_condition_tab",
   "terms_and_condition",
+  "signatures_tab",
+  "customer_signature",
+  "column_break_qxw6c",
+  "authority_signature",
   "amended_from"
  ],
  "fields": [
@@ -201,11 +201,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "signatures_section",
-   "fieldtype": "Section Break",
-   "label": "Signatures"
-  },
-  {
    "allow_on_submit": 1,
    "fieldname": "workflow_state",
    "fieldtype": "Link",
@@ -213,12 +208,17 @@
    "label": "Workflow State",
    "no_copy": 1,
    "options": "Workflow State"
+  },
+  {
+   "fieldname": "signatures_tab",
+   "fieldtype": "Tab Break",
+   "label": "Signatures"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-03-16 12:51:01.567551",
+ "modified": "2023-03-17 11:31:17.598888",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Compliance Agreement",

--- a/one_compliance/one_compliance/doctype/inward_register/inward_register.json
+++ b/one_compliance/one_compliance/doctype/inward_register/inward_register.json
@@ -106,18 +106,18 @@
   {
    "depends_on": "eval:doc.register_type == 'General'",
    "fieldname": "general_register_type",
-   "fieldtype": "Link",
+   "fieldtype": "Table MultiSelect",
    "label": "General Register Type",
    "mandatory_depends_on": "eval:doc.register_type == 'General'",
-   "options": "General Register Type"
+   "options": "General Register Type List"
   },
   {
    "depends_on": "eval:doc.register_type == 'Document'",
    "fieldname": "document_register_type",
-   "fieldtype": "Link",
+   "fieldtype": "Table MultiSelect",
    "label": "Document Register Type",
    "mandatory_depends_on": "eval:doc.register_type == 'Document'",
-   "options": "Document Register Type"
+   "options": "Document Register Type List"
   },
   {
    "depends_on": "eval:doc.received_through == 'Others'",
@@ -184,7 +184,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-03-16 16:55:45.954395",
+ "modified": "2023-03-17 10:14:25.075456",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Inward Register",


### PR DESCRIPTION
## Feature description
Set multi select for document and general register type and customised compliance agreement doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome

## Output screenshots 
 
![Screenshot from 2023-03-17 12-10-29](https://user-images.githubusercontent.com/95274912/225831651-13e5aafb-0461-4f8b-83a0-711393e700c6.png)
