### PR TITLE
feat: Applied dialog instance to show customer credentials

### DIFF
--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -110,9 +110,6 @@ doc_events = {
 	"Project Template": {
 		"after_insert": "one_compliance.one_compliance.doc_events.project_template.update_project_template",
 	}
-    # 'Task':{
-    #     'on_update':'one_compliance.one_compliance.utils.sent_email_notification'
-    # }
 }
 
 # Scheduled Tasks

--- a/one_compliance/one_compliance/doc_events/customer.py
+++ b/one_compliance/one_compliance/doc_events/customer.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe.model.mapper import *
+from frappe import _
 
 """ Method used to set value in standard hidden field """
 
@@ -54,3 +55,16 @@ def filter_contact(doctype, txt, searchfield, start, page_len, filters):
             'page_len': page_len
         })
         return values
+
+""" Method to add customer Credential details """
+
+@frappe.whitelist()
+def add_credential_details(customer,purpose):
+    if frappe.db.exists('Customer Credentials',{'customer':customer}):
+        customer_credential = frappe.db.get_value('Customer Credentials',{'customer':customer})
+        if frappe.db.exists('Credential Details', {'parent':customer_credential,'purpose':purpose}):
+            username, password, url = frappe.db.get_value('Credential Details', {'parent':customer_credential,'purpose':purpose}, ['username', 'password','url'])
+            return [username, password, url]
+        else:
+            frappe.throw(_('Credential not configured for this Purpose'))
+    

--- a/one_compliance/one_compliance/doctype/credential_details/credential_details.json
+++ b/one_compliance/one_compliance/doctype/credential_details/credential_details.json
@@ -28,7 +28,7 @@
   },
   {
    "fieldname": "password",
-   "fieldtype": "Password",
+   "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Password"
   },
@@ -49,7 +49,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-03-18 11:11:44.078951",
+ "modified": "2023-03-21 13:24:24.726587",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Credential Details",

--- a/one_compliance/public/js/customer.js
+++ b/one_compliance/public/js/customer.js
@@ -25,7 +25,77 @@ frappe.ui.form.on('Customer',{
             customer_name: doc.name
           }
         }
-      })
+      });
+      frm.add_custom_button('View Credential', () => {
+				customer_credentials(frm)
+				})
     }
   }
 });
+/* applied dialog instance to show customer Credential */
+let customer_credentials = function (frm) {
+  let d = new frappe.ui.Dialog({
+    title: 'Enter details',
+    fields: [
+      {
+        label: 'Purpose',
+        fieldname: 'purpose',
+        fieldtype: 'Link',
+        options: 'Credential Type'
+      }
+    ],
+    primary_action_label: 'View Credential',
+    primary_action(values) {
+      frappe.call({
+        method:'one_compliance.one_compliance.doc_events.customer.add_credential_details',
+        args:{
+              'customer':frm.doc.name,
+              'purpose':values.purpose
+             },
+        callback:function(r){
+          if (r.message){
+            d.hide();
+            let newd = new frappe.ui.Dialog({
+              title: 'Credential details',
+              fields: [
+                {
+                  label: 'Username',
+                  fieldname: 'username',
+                  fieldtype: 'Data',
+                  read_only: 1,
+                  default:r.message[0]
+                },
+                {
+                  label: 'Password',
+                  fieldame: 'password',
+                  fieldtype: 'Data',
+                  read_only: 1,
+                  default:r.message[1]
+                },
+                {
+                  label: 'Url',
+                  fieldname: 'url',
+                  fieldtype: 'Data',
+                  options: 'URL',
+                  read_only: 1,
+                  default:r.message[2]
+                }
+              ],
+              primary_action_label: 'Close',
+              primary_action(value) {
+                  newd.hide();
+              },
+              secondary_action_label : 'Go To URL',
+              secondary_action(value){
+                window.open(r.message[2])
+
+              }
+          });
+          newd.show();
+          }
+        }
+      })
+    }
+});
+d.show();
+}


### PR DESCRIPTION
## Feature description
-> Applied dialog instance to show customer credentials.

## Analysis and design (optional)
-> Added a purpose field to view the purpose. By selecting the purpose, users can view the related credentials. By selecting the go to url button, users can access the corresponding url in a new window.




## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome

## Output screenshots
![image](https://user-images.githubusercontent.com/114916803/226806219-263e485f-ee4b-4c22-b630-ec09435cf586.png)

![image](https://user-images.githubusercontent.com/114916803/226806287-f5f2d80e-9128-4958-b7f2-77fc56833135.png)
