### PR TITLE
feat: Add custom button to sent clarification message to customer

### DIFF
--- a/one_compliance/one_compliance/doc_events/customer.py
+++ b/one_compliance/one_compliance/doc_events/customer.py
@@ -4,6 +4,7 @@ from frappe.model.mapper import *
 from frappe import _
 from frappe.utils.user import get_users_with_role
 
+
 @frappe.whitelist()
 def set_customer_type_value(doc):
     '''
@@ -90,7 +91,7 @@ def create_user_from_customer(doc):
                 user_doc.first_name = doc.customer_name
                 user_doc.save(ignore_permissions = True)
                 frappe.msgprint('User created for this customer', alert=True, indicator='green')
-                
+
 @frappe.whitelist()
 def custom_button_for_view_Compliance_agreement(customer):
     if frappe.db.exists('Compliance Agreement', {'customer':customer, 'status':'Active'}):
@@ -98,3 +99,11 @@ def custom_button_for_view_Compliance_agreement(customer):
         return compliance_agreement
     else:
         return 0
+
+@frappe.whitelist()
+def send_clarification_message(customer,message):
+    doc = frappe.get_doc('Customer',customer)
+    recipient =doc.email_id
+    subject = "Clarification Request"
+    body = "Dear {},\n\nWe are writing to request clarification on the following matter: {}".format(customer, message)
+    frappe.sendmail(recipients=[recipient],subject=subject, message=body)

--- a/one_compliance/one_compliance/utils.py
+++ b/one_compliance/one_compliance/utils.py
@@ -95,6 +95,7 @@ def view_customer_documents(customer,compliance_sub_category):
             frappe.throw(_('Document not attached for this sub category'))
 
 
+
 @frappe.whitelist()
 def edit_customer_credentials(customer):
     """ Method to edit or add customer Credential """


### PR DESCRIPTION
## Feature description
->  Add custom button to sent clarification message to customer


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome


## Output screenshots 

![image](https://user-images.githubusercontent.com/114916803/228190688-2374fc67-8cef-4441-9ce5-c53acc33df4b.png)
![image](https://user-images.githubusercontent.com/114916803/228191453-7f18627a-217f-41ef-bce4-1333a391950d.png)

 

