### PR TITLE
fix: Set custom button hide if task is template and also set validation to rate field in compliance subcategory

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.js
+++ b/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.js
@@ -3,16 +3,18 @@
 
 frappe.ui.form.on('Compliance Sub Category', {
 	refresh: function(frm) {
-    if(!frm.is_new() && !frm.doc.project_template){
+		if(!frm.is_new() && !frm.doc.project_template){
 			//custom button to create project template and route to  project template doctype
-     frm.add_custom_button('Create Project Template', () =>{
-       frappe.model.open_mapped_doc({
-         method: 'one_compliance.one_compliance.doctype.compliance_sub_category.compliance_sub_category.create_project_template_custom_button',
-         frm: cur_frm
-       });
-     });
-    }
-		set_notification_templates(frm);
+			frm.add_custom_button('Create Project Template', () =>{
+				frappe.model.open_mapped_doc({
+					method: 'one_compliance.one_compliance.doctype.compliance_sub_category.compliance_sub_category.create_project_template_custom_button',
+					frm: cur_frm
+				});
+			});
+		}
+		if(frm.is_new()){
+			set_notification_templates(frm);
+		}
 	}
 });
 
@@ -21,9 +23,8 @@ let set_notification_templates = function(frm){
 		method:'one_compliance.one_compliance.doctype.compliance_sub_category.compliance_sub_category.get_notification_details',
 		callback: (r) => {
 			if(r.message){
-
 				// set value to customer and company
-				if(!frm.doc.task_before_due_date__notification){
+				if(!frm.doc.task_before_due_date_notification){
 					frm.set_value('task_before_due_date_notification', r.message.task_before_due_date_notification)
 				}
 				if(!frm.doc.task_complete_notification){

--- a/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.json
+++ b/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.json
@@ -128,7 +128,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-03-27 14:33:50.753735",
+ "modified": "2023-03-29 09:08:37.762942",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Compliance Sub Category",

--- a/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.py
+++ b/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.py
@@ -4,9 +4,16 @@
 import frappe
 from frappe.model.document import Document
 from frappe.model.mapper import *
+from frappe import _
 
 class ComplianceSubCategory(Document):
-	pass
+	def validate(self):
+		self.validate_rate()
+
+	def validate_rate(self):
+		""" Method to validate rate """
+		if not self.rate :
+			frappe.throw(_('Please Enter Valid Rate'))
 
 @frappe.whitelist()
 def create_project_template_custom_button(source_name, target_doc = None):

--- a/one_compliance/public/js/task.js
+++ b/one_compliance/public/js/task.js
@@ -2,14 +2,16 @@ frappe.ui.form.on('Task',{
   refresh(frm){
     let roles = frappe.user_roles;
     if(roles.includes('Compliance Manager') || roles.includes('Director')){
-      frm.add_custom_button('View Credential', () => {
-        customer_credentials(frm)
-      });
-      frm.add_custom_button('View Document', () => {
-        customer_document(frm)
-      });
+      if (frm.doc.is_template == 0){
+        frm.add_custom_button('View Credential', () => {
+          customer_credentials(frm)
+        });
+        frm.add_custom_button('View Document', () => {
+          customer_document(frm)
+        });
+      }
     }
-  }
+  },
 });
 /* applied dialog instance to show customer Credential */
 


### PR DESCRIPTION

## Feature description
->  Set custom button hide if task is template and also set validation to rate field in compliance subcategory


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome

## Output screenshots 
![image](https://user-images.githubusercontent.com/114916803/228427425-ebf8f4e0-0401-43d3-9a38-e904112ec01a.png)
![image](https://user-images.githubusercontent.com/114916803/228427497-357f091f-ae8a-4914-9048-a927b53d8cf6.png)
![image](https://user-images.githubusercontent.com/114916803/228427527-f3280d02-3bef-4ceb-ac5f-ff04b396625a.png)



