### PR TITLE
feat: Disabled custom buttons in Compliance Agreement and Inward register

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.js
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.js
@@ -29,6 +29,8 @@ frappe.ui.form.on('Compliance Agreement',{
         }
       })
     }
+   disable_assign_task_button(frm)
+
   },
   compliance_category:function(frm){
     set_sub_category_list(frm);
@@ -110,7 +112,7 @@ frappe.ui.form.on('Compliance Category Details',{
       frm.set_value('total',total)
       }
   });
-  
+
 let set_sub_category_list = function(frm){
   frm.call('list_sub_category', {throw_if_missing : true})
     .then(r =>{
@@ -145,6 +147,21 @@ let view_custom_button_project = function(frm){
             }
           })
         })
+      }
+    }
+  })
+}
+
+let disable_assign_task_button = function(frm) {
+  //Function to disable the Assign Task button once the tasks assigned
+  frappe.call({
+    method: 'one_compliance.one_compliance.doctype.compliance_agreement.compliance_agreement.disable_assign_task_button',
+    args: {
+      'name' : frm.doc.name
+    },
+    callback: (r) => {
+      if(r.message) {
+        frm.remove_custom_button('Assign Task')
       }
     }
   })

--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
@@ -80,6 +80,7 @@ class ComplianceAgreement(Document):
 def assign_tasks(source_name, target_doc = None):
 	'''Method to assign tasks for custom button Assign Task and route to Compliance Task Assignement doctype'''
 	def set_missing_values(source, target):
+		target.compliance_agreement = source.name
 		for categories in source.compliance_category:
 			target.append('category', {
 			'compliance_category' : categories.compliance_category
@@ -221,3 +222,9 @@ def check_project_against_customer(customer):
 		return 1
 	else:
 		return 0
+
+@frappe.whitelist()
+def disable_assign_task_button(name):
+	''' Method to check compliance agreement exists in compliance task assignment for disable custom button '''
+	if frappe.db.exists('Compliance Task Assignment', {'compliance_agreement': name}):
+		return 1

--- a/one_compliance/one_compliance/doctype/compliance_category_details/compliance_category_details.json
+++ b/one_compliance/one_compliance/doctype/compliance_category_details/compliance_category_details.json
@@ -17,7 +17,8 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Compliance Category",
-   "options": "Compliance Category"
+   "options": "Compliance Category",
+   "reqd": 1
   },
   {
    "fieldname": "compliance_sub_category",
@@ -39,7 +40,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-03-27 10:58:19.386463",
+ "modified": "2023-04-04 16:33:19.660310",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Compliance Category Details",

--- a/one_compliance/one_compliance/doctype/compliance_task_assignment/compliance_task_assignment.json
+++ b/one_compliance/one_compliance/doctype/compliance_task_assignment/compliance_task_assignment.json
@@ -9,6 +9,9 @@
  "engine": "InnoDB",
  "field_order": [
   "category",
+  "column_break_dl35u",
+  "compliance_agreement",
+  "section_break_taxp7",
   "task_details"
  ],
  "fields": [
@@ -23,11 +26,25 @@
    "fieldtype": "Table",
    "label": "Task Details",
    "options": "Compliance Task Detail"
+  },
+  {
+   "fieldname": "column_break_dl35u",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "compliance_agreement",
+   "fieldtype": "Link",
+   "label": "Compliance Agreement",
+   "options": "Compliance Agreement"
+  },
+  {
+   "fieldname": "section_break_taxp7",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-03-31 14:31:47.632450",
+ "modified": "2023-04-04 16:00:23.993504",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Compliance Task Assignment",

--- a/one_compliance/one_compliance/doctype/inward_register/inward_register.js
+++ b/one_compliance/one_compliance/doctype/inward_register/inward_register.js
@@ -24,10 +24,8 @@ frappe.ui.form.on('Inward Register', {
 		else{
 			frm.set_df_property('edit_posting_date_and_time','hidden',1);
 		}
-		if(frm.doc.digital_signature == 1){
-			frm.add_custom_button('Add/View Digital Signature', () =>{
-				digital_signature(frm)
-			})
+		if(frm.doc.digital_signature == 1&& frm.doc.customer){
+			disable_add_or_view_digital_signature_button(frm)
 		}
 	},
 });
@@ -77,4 +75,20 @@ let digital_signature = function (frm) {
 });
 
 d.show();
+}
+
+let disable_add_or_view_digital_signature_button = function(frm) {
+	frappe.call({
+		method: 'one_compliance.one_compliance.doctype.inward_register.inward_register.disable_add_or_view_digital_signature_button',
+		args: {
+			'customer' : frm.doc.customer
+		},
+		callback: (r) => {
+			if(r.message) {
+				frm.add_custom_button('Add/View Digital Signature', () =>{
+					digital_signature(frm)
+				})
+			}
+		}
+	})
 }

--- a/one_compliance/one_compliance/doctype/inward_register/inward_register.py
+++ b/one_compliance/one_compliance/doctype/inward_register/inward_register.py
@@ -22,3 +22,8 @@ def create_outward_register(source_name, target_doc = None):
         },
         },target_doc,set_missing_values)
     return doc
+
+@frappe.whitelist()
+def disable_add_or_view_digital_signature_button(customer):
+	if not frappe.db.exists('Digital Signature', {'customer' : customer}):
+		return 1


### PR DESCRIPTION


## Feature description
-> Disabled the custom button Assign Task once the tasks assigned in Compliance Agreement
-> Disable the custom button Add/View Digital Signature after the signature updated in Inward Register


## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?
  - Chrome :yes
