### PR TITLE
feat: Hide custom button from Inward and Outward Register

### DIFF
--- a/one_compliance/one_compliance/doctype/inward_register/inward_register.js
+++ b/one_compliance/one_compliance/doctype/inward_register/inward_register.js
@@ -25,6 +25,9 @@ frappe.ui.form.on('Inward Register', {
 			frm.set_df_property('edit_posting_date_and_time','hidden',1);
 		}
 		if(frm.doc.digital_signature == 1 && frm.doc.customer){
+			frm.add_custom_button('Add/View Digital Signature', () =>{
+				digital_signature_dialog(frm)
+			})
 			disable_add_or_view_digital_signature_button(frm)
 		}
 	}
@@ -78,6 +81,7 @@ d.show();
 }
 
 let disable_add_or_view_digital_signature_button = function(frm) {
+	// Function to disable custom button Add/View Digital Signature after once it updated
 	frappe.call({
 		method: 'one_compliance.one_compliance.doctype.inward_register.inward_register.disable_add_or_view_digital_signature_button',
 		args: {
@@ -85,9 +89,7 @@ let disable_add_or_view_digital_signature_button = function(frm) {
 		},
 		callback: (r) => {
 			if(r.message) {
-				frm.add_custom_button('Add/View Digital Signature', () =>{
-					digital_signature_dialog(frm)
-				})
+				frm.remove_custom_button('Add/View Digital Signature')
 			}
 		}
 	})

--- a/one_compliance/one_compliance/doctype/inward_register/inward_register.py
+++ b/one_compliance/one_compliance/doctype/inward_register/inward_register.py
@@ -23,7 +23,11 @@ def create_outward_register(source_name, target_doc = None):
         },target_doc,set_missing_values)
     return doc
 
+
 @frappe.whitelist()
 def disable_add_or_view_digital_signature_button(customer):
-	if not frappe.db.exists('Digital Signature', {'customer' : customer}):
-		return 1
+	''' Method to check is there any value existing in the table with same customer '''
+	if frappe.db.exists('Digital Signature', {'customer' : customer}):
+		digital_signature_doc = frappe.get_doc('Digital Signature', {'customer' : customer})
+		if digital_signature_doc.digital_signature_details:
+			return 1

--- a/one_compliance/one_compliance/doctype/outward_register/outward_register.js
+++ b/one_compliance/one_compliance/doctype/outward_register/outward_register.js
@@ -20,6 +20,7 @@ frappe.ui.form.on('Outward Register', {
 			frm.add_custom_button('Add/View Digital Signature', () =>{
 				digital_signature_dialog(frm)
 			})
+			disable_add_or_view_digital_signature_button(frm)
 		}
 	},
 	onload: function(frm) {
@@ -74,4 +75,20 @@ let digital_signature_dialog = function (frm) {
 });
 
 d.show();
+}
+
+
+let disable_add_or_view_digital_signature_button = function(frm) {
+	// Function to disable custom button Add/View Digital Signature after once it updated
+	frappe.call({
+		method: 'one_compliance.one_compliance.doctype.outward_register.outward_register.disable_add_or_view_digital_signature_button',
+		args: {
+			'customer' : frm.doc.customer
+		},
+		callback: (r) => {
+			if(r.message) {
+				frm.remove_custom_button('Add/View Digital Signature')
+			}
+		}
+	})
 }

--- a/one_compliance/one_compliance/doctype/outward_register/outward_register.json
+++ b/one_compliance/one_compliance/doctype/outward_register/outward_register.json
@@ -207,6 +207,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.if_outward_only == 0",
    "fieldname": "digital_signature",
    "fieldtype": "Check",
    "label": "Digital Signature"
@@ -215,7 +216,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-04-03 10:11:09.718613",
+ "modified": "2023-04-05 12:29:38.933271",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Outward Register",

--- a/one_compliance/one_compliance/doctype/outward_register/outward_register.py
+++ b/one_compliance/one_compliance/doctype/outward_register/outward_register.py
@@ -1,8 +1,17 @@
 # Copyright (c) 2023, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 class OutwardRegister(Document):
 	pass
+
+@frappe.whitelist()
+def disable_add_or_view_digital_signature_button(customer):
+	''' Method to check the register type is outward register in the for updated signature table with same customer '''
+	if frappe.db.exists('Digital Signature', {'customer' : customer}):
+		digital_signature_doc = frappe.get_doc('Digital Signature', {'customer' : customer})
+		for digital_signature in digital_signature_doc.digital_signature_details:
+			if digital_signature.register_type == 'Outward Register':
+				return 1


### PR DESCRIPTION
## Feature description
-> Hide custom button Add/View Digital Signature  from Inward and Outward register after digital signature updated


## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?
  - Chrome :yes
