### PR TITLE
fix:Hide the 'create project' button only if there are projects again…

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.js
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.js
@@ -124,9 +124,10 @@ let set_sub_category_list = function(frm){
 
 let view_custom_button_project = function(frm){
   frappe.call({
-    method : 'one_compliance.one_compliance.doctype.compliance_agreement.compliance_agreement.check_project_against_customer',
+    method : 'one_compliance.one_compliance.doctype.compliance_agreement.compliance_agreement.check_project_against_compliance_sub_category',
     args :{
-      'customer' : frm.doc.customer
+      'compliance_category_details' : frm.doc.compliance_category_details,
+      'compliance_agreement' : frm.doc.name
     },
     callback : (r) => {
       if(r.message){

--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
@@ -216,14 +216,6 @@ def check_exist_list(self, compliance_sub_category):
 	return exist
 
 @frappe.whitelist()
-def check_project_against_customer(customer):
-	'''method used for checking project against customer'''
-	if frappe.db.exists('Project', {'customer': customer}):
-		return 1
-	else:
-		return 0
-
-@frappe.whitelist()
 def disable_assign_task_button(name):
 	''' Method to check compliance agreement exists in compliance task assignment for disable custom button '''
 	if frappe.db.exists('Compliance Task Assignment', {'compliance_agreement': name}):

--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
@@ -228,3 +228,11 @@ def disable_assign_task_button(name):
 	''' Method to check compliance agreement exists in compliance task assignment for disable custom button '''
 	if frappe.db.exists('Compliance Task Assignment', {'compliance_agreement': name}):
 		return 1
+
+@frappe.whitelist()
+def check_project_against_compliance_sub_category(compliance_category_details, compliance_agreement):
+    '''method used for checking project against Compliance Sub Category'''
+    categories = json.loads(compliance_category_details)
+    for category in categories:
+        if frappe.db.exists('Project',{'compliance_agreement':compliance_agreement, 'compliance_sub_category':category.get('compliance_sub_category')}):
+            return True


### PR DESCRIPTION
…st subcategories in that agreement

## Feature description
Hide the „create project“ button only if there are projects against subcategories in that agreement
![Screenshot from 2023-04-05 13-06-52](https://user-images.githubusercontent.com/107603478/230013222-4c02cc2d-6b06-4ca7-af83-8dd052da7144.png)


## Was this feature tested on the browsers?
  - Chrome
