### PR TITLE
feat: Edited doctype Inward Register

### DIFF
--- a/one_compliance/one_compliance/doctype/inward_register/inward_register.js
+++ b/one_compliance/one_compliance/doctype/inward_register/inward_register.js
@@ -24,12 +24,16 @@ frappe.ui.form.on('Inward Register', {
 		else{
 			frm.set_df_property('edit_posting_date_and_time','hidden',1);
 		}
-		if(frm.doc.digital_signature == 1 && frm.doc.customer){
+		if(frm.doc.register_type == 'Digital Signature' && frm.doc.customer){
 			frm.add_custom_button('Add/View Digital Signature', () =>{
 				digital_signature_dialog(frm)
 			})
 			disable_add_or_view_digital_signature_button(frm)
 		}
+	},
+
+	document_register_type: function(frm) {
+		update_document_register_type(frm);
 	}
 });
 /* applied dialog instance to add or view digital signature */
@@ -93,4 +97,50 @@ let disable_add_or_view_digital_signature_button = function(frm) {
 			}
 		}
 	})
+}
+
+let update_document_register_type = function(frm) {
+	// Add or Remove data from  register type table based on multi-select
+	let document_register_type = frm.doc.document_register_type;
+	let document_register_type_length = frm.doc.document_register_type.length;
+	let document_register_type_detail_length = 0
+	if (frm.doc.register_type_detail) {
+		document_register_type_detail_length = frm.doc.register_type_detail.length
+	}
+	if (document_register_type_length > document_register_type_detail_length) {
+		frm.clear_table('register_type_detail')
+		frm.doc.document_register_type.forEach(document_register_type => {
+				let document_register_type_table = frm.add_child('register_type_detail');
+				document_register_type_table.document_register_type = document_register_type.document_register_type
+				frm.refresh_field('register_type_detail')
+		})
+	}
+  else if (document_register_type_length < document_register_type_detail_length) {
+		if (document_register_type_length) {
+			document_register_type_length = frm.doc.document_register_type.length
+			let document_register_types = []
+			frm.doc.document_register_type.forEach(document_register_type => {
+				document_register_types.push(document_register_type.document_register_type)
+			});
+			delete_row_from_document_register_type_table(document_register_types)
+			document_register_type = frm.doc.document_register_type
+			document_register_type_length = frm.doc.document_register_type.length
+		}
+		else {
+			frm.clear_table('register_type_detail')
+			frm.refresh_field('register_type_detail')
+		}
+	}
+}
+
+
+let delete_row_from_document_register_type_table = function (document_register_types) {
+		let table = cur_frm.doc.register_type_detail || [];
+		let i = table.length;
+		while (i--) {
+			if(!document_register_types.includes(table[i].document_register_type)) {
+				cur_frm.get_field('register_type_detail').grid.grid_rows[i].remove();
+			}
+		}
+		cur_frm.refresh_field('register_type_detail')
 }

--- a/one_compliance/one_compliance/doctype/inward_register/inward_register.json
+++ b/one_compliance/one_compliance/doctype/inward_register/inward_register.json
@@ -1,13 +1,12 @@
 {
  "actions": [],
  "autoname": "RT.####",
- "creation": "2023-03-08 15:04:55.839345",
+ "creation": "2023-04-10 16:03:56.760055",
  "default_view": "List",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "digital_signature",
   "register_type",
   "general_register_type",
   "document_register_type",
@@ -23,6 +22,8 @@
   "customer",
   "received_through",
   "specify_others",
+  "section_break_9jupg",
+  "register_type_detail",
   "signature_tab",
   "section_break_slzqk",
   "authority_signature",
@@ -39,7 +40,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Register Type",
-   "options": "\nGeneral\nDocument",
+   "options": "\nGeneral\nDocument\nDigital Signature",
    "reqd": 1
   },
   {
@@ -129,7 +130,7 @@
    "mandatory_depends_on": "eval:doc.received_through == 'Others'"
   },
   {
-   "depends_on": "eval:doc.register_type == 'Document'",
+   "depends_on": "eval:doc.register_type == 'Document' || doc.register_type == 'Digital Signature'",
    "fieldname": "received_through",
    "fieldtype": "Select",
    "label": "Received Through",
@@ -169,7 +170,7 @@
    "fieldtype": "Select",
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Open\nReceived\nPending\nOverdue"
+   "options": "Open\nReturned\nPartially Returned"
   },
   {
    "fieldname": "authority_signature",
@@ -183,16 +184,22 @@
    "label": "Edit Posting Date and Time"
   },
   {
-   "default": "0",
-   "fieldname": "digital_signature",
-   "fieldtype": "Check",
-   "label": "Digital Signature"
+   "fieldname": "section_break_9jupg",
+   "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "eval:doc.document_register_type",
+   "fieldname": "register_type_detail",
+   "fieldtype": "Table",
+   "label": "Register Type Detail",
+   "options": "Register Type Detail",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-03-31 15:05:12.222948",
+ "modified": "2023-04-11 12:02:34.666195",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Inward Register",

--- a/one_compliance/one_compliance/doctype/inward_register/inward_register.py
+++ b/one_compliance/one_compliance/doctype/inward_register/inward_register.py
@@ -7,7 +7,28 @@ from frappe.model.mapper import *
 
 
 class InwardRegister(Document):
-	pass
+	def validate(self):
+		self.change_inward_status()
+
+	def change_inward_status(self):
+		''' Method to change the status of Inward Doctype based on status of child table '''
+		is_returned = True
+		is_issued = True
+		for register_types in self.register_type_detail:
+			if register_types.status != 'Issued':
+				is_issued = False
+			if register_types.status != 'Returned':
+				is_returned = False
+		if is_issued == True:
+			self.status = 'Open'
+		else:
+			if is_returned == True:
+				self.status = 'Returned'
+			else:
+				self.status = 'Partially Returned'
+
+
+
 
 @frappe.whitelist()
 def create_outward_register(source_name, target_doc = None):

--- a/one_compliance/one_compliance/doctype/register_type_detail/register_type_detail.json
+++ b/one_compliance/one_compliance/doctype/register_type_detail/register_type_detail.json
@@ -1,0 +1,51 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-04-10 10:13:13.135400",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "document_register_type",
+  "status",
+  "outward_register"
+ ],
+ "fields": [
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "\nIssued\nReturned"
+  },
+  {
+   "fieldname": "outward_register",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Outward Register",
+   "options": "Outward Register"
+  },
+  {
+   "fieldname": "document_register_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Document Register Type",
+   "options": "Document Register Type"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2023-04-10 14:49:18.761912",
+ "modified_by": "Administrator",
+ "module": "One Compliance",
+ "name": "Register Type Detail",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_compliance/one_compliance/doctype/register_type_detail/register_type_detail.py
+++ b/one_compliance/one_compliance/doctype/register_type_detail/register_type_detail.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class RegisterTypeDetail(Document):
+	pass


### PR DESCRIPTION
## Feature description
-> Added Digital Signature as a Register Type 
-> If Register Type is Digital Signature then removed mandatory
-> Removed Digital Signature checkbox and handled all conditions based on Register Type
-> Add one table ( Register Type Detail ) - Auto Populate on selection of Document register Type in Register.
-> Register Type Detail includes- Document Register Type , Status ( Select - Issued, Returned ), Outward Register - Link to Outward Register
-> If all Document Register Type are 'Returned' then inward register status set to 'Returned', If any returned then Partially Returned other wise 'Issued'


## Is there any existing behavior change of other features due to this code change?
 - No
## Was this feature tested on the browsers?
  - Chrome : yes

## Output screenshots 
fetch document register type into child table

![image](https://user-images.githubusercontent.com/115983752/231080284-27c40f15-fbc6-4da0-8ff3-2ddfb862dbe2.png)

![image](https://user-images.githubusercontent.com/115983752/231080354-da57c4c8-77b0-4d75-955d-5efb111e1808.png)

IF all is returned

![Screenshot from 2023-04-11 11-08-10](https://user-images.githubusercontent.com/115983752/231079077-7d80920c-0133-4457-bbea-aa92eecdd207.png)


![Screenshot from 2023-04-11 11-08-20](https://user-images.githubusercontent.com/115983752/231079345-274ff1e8-da75-4703-821c-5bd66f851926.png)

if it include both issued and returned

![Screenshot from 2023-04-11 11-09-18](https://user-images.githubusercontent.com/115983752/231079220-666eb188-d32a-463d-9c1a-8f45c0aa9d20.png)

![Screenshot from 2023-04-11 11-09-24](https://user-images.githubusercontent.com/115983752/231079470-1d6f0791-5fc6-45ba-9174-13e9f4703ef3.png)

if all is Issued

![Screenshot from 2023-04-11 11-08-43](https://user-images.githubusercontent.com/115983752/231079136-39cf6c08-64b4-4710-b339-7a8e0da63d43.png)

![Screenshot from 2023-04-11 11-08-55](https://user-images.githubusercontent.com/115983752/231079445-9f7a8bbe-e8d9-4e02-8a78-fcab7024fbe7.png)

