### PR TITLE
feat:Added the DIN number field as a unique field and the pan number …

### DIFF
--- a/one_compliance/one_compliance/doctype/digital_signature/digital_signature.js
+++ b/one_compliance/one_compliance/doctype/digital_signature/digital_signature.js
@@ -14,13 +14,40 @@ frappe.ui.form.on('Digital Signature', {
             frappe.db.get_value('Outward Register', prev_route[2], 'customer').then(r => {
                 frm.set_value('customer', r.message.customer);
             });
+    
         }
     },
     refresh: function (frm) {
-      if(frm.is_new()){
+        if(frm.is_new()){
   			set_notification_templates(frm);
   		}
+    },
+    customer: function (frm) {
+        if(frm.doc.customer){
+            frappe.call({
+                method: 'one_compliance.one_compliance.doctype.digital_signature.digital_signature.validation_on_company_name',
+                    args:{
+                        'customer':frm.doc.customer
+                          },
+                          callback: (r) =>{
+                            if (r.message){
+                             frm.set_value('company_name',frm.doc.customer)
+                            }
+                            else{
+                                frm.set_value('company_name','')
+                            }
+                          }
+                    })
+  		}
+       
+    },
+
+    notify_on_expiration: function (frm) {
+        if (frm.doc.notify_on_expiration == 1 ) {
+            frappe.msgprint('Make sure the Director Email is provided.')   
+        }
     }
+
 });
 
 let set_notification_templates = function(frm){

--- a/one_compliance/one_compliance/doctype/digital_signature/digital_signature.json
+++ b/one_compliance/one_compliance/doctype/digital_signature/digital_signature.json
@@ -17,6 +17,8 @@
   "column_break_tcpzq",
   "customer_name",
   "expiry_date",
+  "pan_number",
+  "din_number",
   "notify_on_expiration",
   "notify_before",
   "notify_before_unit",
@@ -139,11 +141,24 @@
   {
    "fieldname": "section_break_yhybq",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "pan_number",
+   "fieldtype": "Data",
+   "label": "PAN Number",
+   "reqd": 1
+  },
+  {
+   "fieldname": "din_number",
+   "fieldtype": "Data",
+   "label": "DIN Number",
+   "reqd": 1,
+   "unique": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-04-01 16:41:44.754175",
+ "modified": "2023-04-12 15:23:03.968761",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Digital Signature",

--- a/one_compliance/one_compliance/doctype/digital_signature/digital_signature.py
+++ b/one_compliance/one_compliance/doctype/digital_signature/digital_signature.py
@@ -33,3 +33,9 @@ class DigitalSignature(Document):
 def get_notification_details():
 	doc = frappe.get_doc('Compliance Settings')
 	return doc
+
+@frappe.whitelist()
+def validation_on_company_name(customer):
+	compliance_customer_type = frappe.db.get_value('Customer',customer,'compliance_customer_type')
+	if not compliance_customer_type == 'Individual':
+		return True


### PR DESCRIPTION
…field as a mandatory field, then added a warning message when enabling the Notify on Expiration check box, and when selecting the individual field, the company field will be blank, and other customer types selection time will set the company field as the same name of the customer

## Feature description
A
![Screenshot from 2023-04-12 16-29-41](https://user-images.githubusercontent.com/107603478/231438113-ac00d40e-cdac-498c-b5b3-fab3468ad76a.png)
![Screenshot from 2023-04-12 16-29-29](https://user-images.githubusercontent.com/107603478/231438135-20660b88-ccd7-4f54-a5cc-bd269241f074.png)
dded the DIN number field as a unique field and the pan number field as a mandatory field, then added a warning message when enabling the Notify on Expiration check box, and when selecting the individual field, the company field will be blank, and other customer types selection time will set the company field as the same name of the customer.
## Was this feature tested on the browsers?
  - Chrome