### PR TITLE
feat: Edited doctype Outward Register

### DIFF
--- a/one_compliance/one_compliance/doctype/inward_register/inward_register.json
+++ b/one_compliance/one_compliance/doctype/inward_register/inward_register.json
@@ -56,7 +56,7 @@
    "fieldname": "customer",
    "fieldtype": "Link",
    "label": "Customer",
-   "mandatory_depends_on": "eval:doc.digital_signature == 1",
+   "mandatory_depends_on": "eval:doc.register_type == 'Digital Signature'",
    "options": "Customer"
   },
   {
@@ -130,7 +130,7 @@
    "mandatory_depends_on": "eval:doc.received_through == 'Others'"
   },
   {
-   "depends_on": "eval:doc.register_type == 'Document' || doc.register_type == 'Digital Signature'",
+   "depends_on": "eval:doc.register_type == 'Document'",
    "fieldname": "received_through",
    "fieldtype": "Select",
    "label": "Received Through",
@@ -188,18 +188,18 @@
    "fieldtype": "Section Break"
   },
   {
+   "allow_on_submit": 1,
    "depends_on": "eval:doc.document_register_type",
    "fieldname": "register_type_detail",
    "fieldtype": "Table",
    "label": "Register Type Detail",
-   "options": "Register Type Detail",
-   "read_only": 1
+   "options": "Register Type Detail"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-04-11 12:02:34.666195",
+ "modified": "2023-04-18 09:43:01.713455",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Inward Register",

--- a/one_compliance/one_compliance/doctype/inward_register/inward_register.py
+++ b/one_compliance/one_compliance/doctype/inward_register/inward_register.py
@@ -32,17 +32,25 @@ class InwardRegister(Document):
 
 @frappe.whitelist()
 def create_outward_register(source_name, target_doc = None):
-    def set_missing_values(source, target):
-        target.register_type = source.register_type
-    doc = get_mapped_doc(
-        'Inward Register',
-        source_name,
-        {
-        'Inward Register': {
-        'doctype': 'Outward Register',
-        },
-        },target_doc,set_missing_values)
-    return doc
+	''' Method to route to Outward Register from Inward Register '''
+	def set_missing_values(source, target):
+		target.register_type = source.register_type
+		target.customer = source.customer
+		target.document_register_type = []
+		for register_types in source.register_type_detail:
+			if register_types.status == 'Issued':
+				target.append('document_register_type', {
+				'document_register_type' : register_types.document_register_type
+				})
+	doc = get_mapped_doc(
+		'Inward Register',
+		source_name,
+		{
+		'Inward Register': {
+		'doctype': 'Outward Register',
+		},
+		},target_doc, set_missing_values)
+	return doc
 
 
 @frappe.whitelist()

--- a/one_compliance/one_compliance/doctype/outward_register/outward_register.js
+++ b/one_compliance/one_compliance/doctype/outward_register/outward_register.js
@@ -16,7 +16,7 @@ frappe.ui.form.on('Outward Register', {
 		else {
 			frm.set_df_property('edit_return_date_and_time','hidden',1);
 		}
-		if(frm.doc.digital_signature == 1){
+		if(frm.doc.register_type == 'Digital Signature' && frm.doc.customer){
 			frm.add_custom_button('Add/View Digital Signature', () =>{
 				digital_signature_dialog(frm)
 			})

--- a/one_compliance/one_compliance/doctype/outward_register/outward_register.json
+++ b/one_compliance/one_compliance/doctype/outward_register/outward_register.json
@@ -9,7 +9,6 @@
  "engine": "InnoDB",
  "field_order": [
   "if_outward_only",
-  "digital_signature",
   "inward_register",
   "register_type",
   "general_register_type",
@@ -22,7 +21,6 @@
   "returned_date",
   "returned_time",
   "edit_return_date_and_time",
-  "status",
   "customer",
   "returned_through",
   "specify_others",
@@ -43,7 +41,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Register Type",
-   "options": "\nGeneral\nDocument",
+   "options": "\nGeneral\nDocument\nDigital Signature",
    "reqd": 1
   },
   {
@@ -126,23 +124,6 @@
    "options": "General Register Type List"
   },
   {
-   "depends_on": "eval:doc.register_type == 'Document'",
-   "fetch_from": "inward_register.document_register_type",
-   "fieldname": "document_register_type",
-   "fieldtype": "Table MultiSelect",
-   "label": "Document Register Type",
-   "mandatory_depends_on": "eval:doc.register_type == 'Document'",
-   "options": "Document Register Type List"
-  },
-  {
-   "fieldname": "status",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Status",
-   "options": "open\nPartially Returned\nReturned\nPending"
-  },
-  {
    "fieldname": "signature_tab",
    "fieldtype": "Tab Break",
    "label": "Signature"
@@ -173,6 +154,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:!(doc.inward_register)",
    "fieldname": "if_outward_only",
    "fieldtype": "Check",
    "label": "If Outward Only"
@@ -206,17 +188,18 @@
    "label": "Edit Return Date and Time"
   },
   {
-   "default": "0",
-   "depends_on": "eval:doc.if_outward_only == 0",
-   "fieldname": "digital_signature",
-   "fieldtype": "Check",
-   "label": "Digital Signature"
+   "depends_on": "eval:doc.register_type == 'Document'",
+   "fieldname": "document_register_type",
+   "fieldtype": "Table MultiSelect",
+   "label": "Document Register Type",
+   "mandatory_depends_on": "eval:doc.register_type == 'Document'",
+   "options": "Document Register Type List"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-04-05 12:29:38.933271",
+ "modified": "2023-04-13 15:38:47.531299",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Outward Register",

--- a/one_compliance/one_compliance/doctype/outward_register/outward_register.py
+++ b/one_compliance/one_compliance/doctype/outward_register/outward_register.py
@@ -5,7 +5,21 @@ import frappe
 from frappe.model.document import Document
 
 class OutwardRegister(Document):
-	pass
+
+	def on_submit(self):
+		self.update_inward_child_table()
+
+	def update_inward_child_table(self):
+		''' Method to update status of Inward child table based on Outward child table '''
+		inward_doc = frappe.get_doc('Inward Register', self.inward_register)
+		for document_types in self.document_register_type:
+			document_doc = document_types.document_register_type
+			for register_types in inward_doc.register_type_detail:
+				if register_types.document_register_type == document_doc:
+					register_types.status = 'Returned'
+					register_types.outward_register = self.name
+		inward_doc.save()
+
 
 @frappe.whitelist()
 def disable_add_or_view_digital_signature_button(customer):

--- a/one_compliance/one_compliance/doctype/register_type_detail/register_type_detail.json
+++ b/one_compliance/one_compliance/doctype/register_type_detail/register_type_detail.json
@@ -12,20 +12,25 @@
  ],
  "fields": [
   {
+   "allow_on_submit": 1,
+   "default": "Issued",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "\nIssued\nReturned"
+   "options": "Issued\nReturned",
+   "read_only": 1
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "outward_register",
    "fieldtype": "Link",
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Outward Register",
-   "options": "Outward Register"
+   "options": "Outward Register",
+   "read_only": 1
   },
   {
    "fieldname": "document_register_type",
@@ -39,7 +44,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-04-10 14:49:18.761912",
+ "modified": "2023-04-18 09:51:03.526127",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Register Type Detail",


### PR DESCRIPTION
## Feature description
-> Fetch Details from Inward
-> Removed status field add digital signature as register type
-> Removed if outward only checkbox if inward is selected
-> Removed Digital signature checkbox and handled conditions based on register type
-> Set the status and outward register field of inward child table if the register type is returned
-> Set the status of inward child table into 'Returned' on the basis of submission of outward doctype.
-> Set the filed status and outward register in child tablein inward  readonly 
-> Set the filter on document register type field that it will contain the values who have the status in inward child table as 'Issued'


## Is there any existing behavior change of other features due to this code change?
  - No

## Was this feature tested on the browsers?
  - Chrome : yes

## Output screenshots
![image](https://user-images.githubusercontent.com/115983752/232710453-54e7ab95-a03d-4694-bc87-23f84dc3a924.png)
![image](https://user-images.githubusercontent.com/115983752/232710660-94389131-6134-4923-bded-ce47990c7b2b.png)
