### PR TITLE
feat: Applied filters and edited doctype Inward Register and Outward Register

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.js
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.js
@@ -4,7 +4,10 @@ frappe.ui.form.on('Compliance Agreement',{
       // setting filer for sub category //
       let child = locals[cdt][cdn];
           return {
-              filters: {'compliance_category': child.compliance_category}
+              filters: {
+                'compliance_category': child.compliance_category,
+                enabled: 1
+              }
           };
       });
 

--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
@@ -129,7 +129,7 @@ def set_value_in_status():
 
 def get_compliance_sub_category_list(compliance_category):
 	'''method used for list sub category'''
-	sub_category_list = frappe.db.get_list('Compliance Sub Category', filters = {'compliance_category':compliance_category.compliance_category}, fields = ['rate','name','compliance_category'])
+	sub_category_list = frappe.db.get_list('Compliance Sub Category', filters = {'compliance_category':compliance_category.compliance_category, 'enabled':1}, fields = ['rate','name','compliance_category'])
 	return sub_category_list
 
 def check_exist_list(self, compliance_sub_category):

--- a/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.js
+++ b/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.js
@@ -2,7 +2,68 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Compliance Settings', {
-	// refresh: function(frm) {
+	refresh: function(frm) {
+    //filter for task_before_due_date_notification based on doctype
+    frm.set_query('task_before_due_date_notification', function(){
+      return {
+        filters: {
+          doctype_name : 'Task'
+        }
+      }
+    })
 
-	// }
+    //filter for task_overdue_notification_for_employee based on doctype
+    frm.set_query('task_overdue_notification_for_employee', function(){
+      return {
+        filters: {
+          doctype_name : 'Task'
+        }
+      }
+    })
+
+    //filter for task_overdue_notification_for_director based on doctype
+    frm.set_query('task_overdue_notification_for_director', function(){
+      return {
+        filters: {
+          doctype_name : 'Task'
+        }
+      }
+    })
+
+    //filter for task_complete_notification_for_director based on doctype
+    frm.set_query('task_complete_notification_for_director', function(){
+      return {
+        filters: {
+          doctype_name : 'Task'
+        }
+      }
+    })
+
+    //filter for no_action_taken_notification_for_director based on doctype
+    frm.set_query('no_action_taken_notification_for_director', function(){
+      return {
+        filters: {
+          doctype_name : 'Task'
+        }
+      }
+    })
+
+    //filter for project_complete_notification_for_customer based on doctype
+    frm.set_query('project_complete_notification_for_customer', function(){
+      return {
+        filters: {
+          doctype_name : 'Task'
+        }
+      }
+    })
+
+    //filter for digital_signature_expiry_notification based on doctype
+    frm.set_query('digital_signature_expiry_notification', function(){
+      return {
+        filters: {
+          doctype_name : 'Digital Signature'
+        }
+      }
+    })
+	}
 });

--- a/one_compliance/one_compliance/doctype/inward_register/inward_register.json
+++ b/one_compliance/one_compliance/doctype/inward_register/inward_register.json
@@ -91,7 +91,7 @@
   },
   {
    "fieldname": "person_contact_number",
-   "fieldtype": "Data",
+   "fieldtype": "Phone",
    "label": "Person Contact Number",
    "reqd": 1
   },
@@ -165,12 +165,14 @@
    "label": "Remarks"
   },
   {
+   "allow_on_submit": 1,
    "depends_on": "eval:doc.register_type == 'Document'",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Open\nReturned\nPartially Returned"
+   "options": "Open\nClosed\nPartially Returned",
+   "read_only": 1
   },
   {
    "fieldname": "authority_signature",
@@ -193,13 +195,14 @@
    "fieldname": "register_type_detail",
    "fieldtype": "Table",
    "label": "Register Type Detail",
-   "options": "Register Type Detail"
+   "options": "Register Type Detail",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-04-18 09:43:01.713455",
+ "modified": "2023-04-20 14:48:19.655762",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Inward Register",

--- a/one_compliance/one_compliance/doctype/inward_register/inward_register.py
+++ b/one_compliance/one_compliance/doctype/inward_register/inward_register.py
@@ -7,7 +7,7 @@ from frappe.model.mapper import *
 
 
 class InwardRegister(Document):
-	def validate(self):
+	def on_update_after_submit(self):
 		self.change_inward_status()
 
 	def change_inward_status(self):
@@ -20,14 +20,12 @@ class InwardRegister(Document):
 			if register_types.status != 'Returned':
 				is_returned = False
 		if is_issued == True:
-			self.status = 'Open'
+			frappe.db.set_value('Inward Register', self.name, 'status', 'Open')
 		else:
 			if is_returned == True:
-				self.status = 'Returned'
+				frappe.db.set_value('Inward Register', self.name, 'status', 'Closed')
 			else:
-				self.status = 'Partially Returned'
-
-
+				frappe.db.set_value('Inward Register', self.name, 'status', 'Partially Returned')
 
 
 @frappe.whitelist()

--- a/one_compliance/one_compliance/doctype/outward_register/outward_register.js
+++ b/one_compliance/one_compliance/doctype/outward_register/outward_register.js
@@ -3,6 +3,27 @@
 
 frappe.ui.form.on('Outward Register', {
 	refresh: function(frm) {
+
+		//set filter for inward register field 
+		frm.set_query('inward_register', function() {
+			return {
+				filters: {
+					status: ['not in', ['Closed']]
+				}
+			}
+		});
+
+		frm.set_query('document_register_type', function(doc, cdt, cdn) {
+			// To set filter for document register type field
+            var d = locals[cdt][cdn];
+							return {
+								query: 'one_compliance.one_compliance.doctype.outward_register.outward_register.set_filter_for_document_register_type',
+								filters: {
+									'inward_register': frm.doc.inward_register
+								}
+							};
+        });
+
     if(frm.is_new()) {
 			//Set the return_by default as session user
       frm.set_value("returned_by",frappe.session.user)

--- a/one_compliance/one_compliance/doctype/outward_register/outward_register.json
+++ b/one_compliance/one_compliance/doctype/outward_register/outward_register.json
@@ -68,7 +68,7 @@
   },
   {
    "fieldname": "receiver_contact_number",
-   "fieldtype": "Data",
+   "fieldtype": "Phone",
    "label": "Receiver Contact Number",
    "reqd": 1
   },
@@ -88,7 +88,7 @@
    "fieldname": "customer",
    "fieldtype": "Link",
    "label": "Customer",
-   "mandatory_depends_on": "eval:doc.digital_signature == 1",
+   "mandatory_depends_on": "eval:doc.register_type == 'Digital Signature'",
    "options": "Customer"
   },
   {
@@ -199,7 +199,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-04-13 15:38:47.531299",
+ "modified": "2023-04-20 14:49:15.114756",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Outward Register",

--- a/one_compliance/one_compliance/doctype/outward_register/outward_register.py
+++ b/one_compliance/one_compliance/doctype/outward_register/outward_register.py
@@ -29,3 +29,23 @@ def disable_add_or_view_digital_signature_button(customer):
 		for digital_signature in digital_signature_doc.digital_signature_details:
 			if digital_signature.register_type == 'Outward Register':
 				return 1
+
+@frappe.whitelist()
+def set_filter_for_document_register_type(doctype, txt, searchfield, start, page_len, filters):
+	''' Method to set filter on document register type field to get Issued document registers '''
+	query = '''
+		SELECT
+			rtd.document_register_type
+		FROM
+			`tabRegister Type Detail` as rtd ,
+			`tabInward Register` as ir
+		WHERE
+			ir.name = rtd.parent AND
+			rtd.status = 'Issued' AND
+			ir.name = %(inward_register)s
+		'''
+	values = frappe.db.sql(query.format(**{
+		}), {
+		'inward_register': filters['inward_register'],
+	})
+	return values


### PR DESCRIPTION

## Feature description
-> Applied filter for inward register field in Outward Register doctype
-> Applied filter for document register type filed in outward register doctype to get the issued document registers
-> Applied filter in compliance settings for notification
-> Applied filter for sub category in Compliance Agreement doctype

## Is there any existing behavior change of other features due to this code change?
  - No
## Was this feature tested on the browsers?
  - Chrome : yes

## Output screenshots
![image](https://user-images.githubusercontent.com/115983752/233333088-974d16a8-8d5f-4912-b7c1-9cb9354614e5.png)
![image](https://user-images.githubusercontent.com/115983752/233333178-b408e314-2134-42f6-b0e8-6c23391025c8.png)
