### PR TITLE
fix:project name error in sales invoice

### DIFF
--- a/one_compliance/one_compliance/doc_events/sales_invoice.py
+++ b/one_compliance/one_compliance/doc_events/sales_invoice.py
@@ -2,5 +2,5 @@ import frappe
 
 def sales_invoice_on_submit(doc, method):
     if doc.project:
-        frappe.db.set_value('Project', project, 'status', 'Invoiced')
+        frappe.db.set_value('Project', doc.project, 'status', 'Invoiced')
         frappe.db.commit()


### PR DESCRIPTION
## Feature description
Fixed the project name defining error while submitting a sales invoice.



## Output screenshots (optional)
![Screenshot from 2023-09-29 11-34-15](https://github.com/efeone/one_compliance/assets/138565705/9b862097-cb8a-41d1-8786-3e2259d1d041)




## Was this feature tested on the browsers?
  - Chrome
 
