### PR TITLE
feat:Created doctype compliance Item

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_item/compliance_item.js
+++ b/one_compliance/one_compliance/doctype/compliance_item/compliance_item.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, efeone and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Compliance Item', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/one_compliance/one_compliance/doctype/compliance_item/compliance_item.json
+++ b/one_compliance/one_compliance/doctype/compliance_item/compliance_item.json
@@ -1,0 +1,89 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:item_code",
+ "creation": "2023-11-02 17:00:46.522371",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "item_code",
+  "item_name",
+  "compliance_sub_category",
+  "column_break_gllai",
+  "item_group",
+  "is_service_item"
+ ],
+ "fields": [
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Data",
+   "label": "Item Code",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "item_name",
+   "fieldtype": "Data",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Item Name"
+  },
+  {
+   "fieldname": "item_group",
+   "fieldtype": "Data",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Item Group",
+   "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_service_item",
+   "fieldtype": "Check",
+   "label": "Is Service Item"
+  },
+  {
+   "fieldname": "compliance_sub_category",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Compliance Sub Category"
+  },
+  {
+   "fieldname": "column_break_gllai",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2023-11-06 12:20:12.376985",
+ "modified_by": "Administrator",
+ "module": "One Compliance",
+ "name": "Compliance Item",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "search_fields": "item_name, item_group",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "item_name",
+ "track_changes": 1
+}

--- a/one_compliance/one_compliance/doctype/compliance_item/compliance_item.py
+++ b/one_compliance/one_compliance/doctype/compliance_item/compliance_item.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class ComplianceItem(Document):
+	pass

--- a/one_compliance/one_compliance/doctype/compliance_item/test_compliance_item.py
+++ b/one_compliance/one_compliance/doctype/compliance_item/test_compliance_item.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestComplianceItem(FrappeTestCase):
+	pass

--- a/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.js
+++ b/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.js
@@ -2,6 +2,31 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Compliance Sub Category', {
+	before_save: function(frm) {
+        if (frm.doc.is_billable && frm.doc.is_service_item) {
+            const item_name = frm.doc.compliance_item;
+            const item_group = "Services";
+            const is_service_item = frm.doc.is_service_item;
+						const sub_category = frm.doc.sub_category;
+
+            frappe.call({
+                method: 'one_compliance.one_compliance.doctype.compliance_sub_category.compliance_sub_category.create_compliance_item_from_sub_category',
+                args: {
+                    item: item_name,
+                    item_group: item_group,
+                    is_service_item: is_service_item,
+										sub_category:sub_category
+                },
+                callback: function(r) {
+                    if (r.message) {
+                        console.log('Compliance Item Created:', r.message);
+                    } else {
+                        console.log('Failed to create Compliance Item');
+                    }
+                }
+            });
+        }
+    },
 	refresh: function(frm) {
 		let compliance_category = frm.doc.compliance_category
 		// Applied filter in child table for active employee
@@ -34,6 +59,27 @@ frappe.ui.form.on('Compliance Sub Category', {
 		}
 		if(frm.is_new()){
 			set_notification_templates(frm);
+		}
+		if(frm.doc.is_billable && frm.doc.is_service_item){
+			frm.add_custom_button(__('Change Item'), function() {
+            const new_item_name = frm.doc.compliance_item;
+						const sub_category = frm.doc.sub_category;
+
+                if (new_item_name) {
+                    frappe.call({
+                        method: 'one_compliance.one_compliance.doctype.compliance_sub_category.compliance_sub_category.change_item_and_update_compliance',
+                        args: {
+                            new_item_name: new_item_name,
+														sub_category:sub_category
+                        },
+                        callback: function(response) {
+                            if (response.message) {
+                                frm.reload_doc();
+                            }
+                        }
+                    });
+                }
+        });
 		}
 	},
 	validate: function(frm) {

--- a/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.json
+++ b/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.json
@@ -20,6 +20,8 @@
   "enabled",
   "is_billable",
   "rate",
+  "compliance_item",
+  "is_service_item",
   "category_type",
   "department_details_section",
   "department",
@@ -40,8 +42,10 @@
  ],
  "fields": [
   {
+   "columns": 1,
    "fieldname": "compliance_category",
    "fieldtype": "Link",
+   "in_filter": 1,
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Compliance Category",
@@ -52,6 +56,7 @@
   {
    "fieldname": "sub_category",
    "fieldtype": "Data",
+   "in_filter": 1,
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": " Sub Category",
@@ -69,9 +74,11 @@
    "fieldtype": "Column Break"
   },
   {
+   "columns": 1,
    "depends_on": "is_billable",
    "fieldname": "rate",
    "fieldtype": "Currency",
+   "in_list_view": 1,
    "label": "Rate",
    "mandatory_depends_on": "is_billable",
    "non_negative": 1,
@@ -214,6 +221,9 @@
    "fetch_from": "compliance_category.category_type",
    "fieldname": "category_type",
    "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Category Type",
    "options": "Category Type",
    "reqd": 1
@@ -224,11 +234,25 @@
    "label": "Project Before Due Date Notification ",
    "options": "Notification Template",
    "reqd": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "is_billable",
+   "fieldname": "is_service_item",
+   "fieldtype": "Check",
+   "label": "Is Service Item"
+  },
+  {
+   "depends_on": "is_billable",
+   "fieldname": "compliance_item",
+   "fieldtype": "Data",
+   "label": "Compliance Item",
+   "mandatory_depends_on": "is_billable"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-10-11 17:45:43.195862",
+ "modified": "2023-11-04 12:53:40.481503",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Compliance Sub Category",
@@ -302,7 +326,9 @@
    "share": 1
   }
  ],
+ "search_fields": "sub_category,compliance_category,category_type",
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "title_field": "sub_category"
 }


### PR DESCRIPTION
## Feature description
Created doctype compliance item. Implemented the creation of compliance item from compliance sub category.

## Solution description
Added field compliance item and is service item check field in compliance sub category doctype. Create compliance item from compliance sub category, if it is service item.

## Output screenshots
![image](https://github.com/efeone/one_compliance/assets/84098652/265783b9-f978-4bde-8f01-82eba7cafeae)
![image](https://github.com/efeone/one_compliance/assets/84098652/3b57c78a-c01e-4b00-8eea-14c22c2d2e82)
![image](https://github.com/efeone/one_compliance/assets/84098652/c568f1a9-2cad-4b1a-b6fe-3543c6ba0d08)


## Areas affected and ensured
Compliance sub category doctype is affected and ensured.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome