### PR TITLE
feat:Modify Item along with change in Compliance Sub Category

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.js
+++ b/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.js
@@ -35,6 +35,23 @@ frappe.ui.form.on('Compliance Sub Category', {
 		if(frm.is_new()){
 			set_notification_templates(frm);
 		}
+		if (frm.doc.item_code) {
+        if (frm.doc.enabled) {
+            frappe.call({
+                method: 'one_compliance.one_compliance.doctype.compliance_sub_category.compliance_sub_category.enable_related_item',
+                args: {
+                    'item_name': frm.doc.item_code
+                }
+            });
+        } else {
+            frappe.call({
+                method: 'one_compliance.one_compliance.doctype.compliance_sub_category.compliance_sub_category.disable_related_item',
+                args: {
+                    'item_name': frm.doc.item_code
+                }
+            });
+        }
+    }
 	},
 	validate: function(frm) {
 		if (frm.doc.day) {
@@ -49,7 +66,7 @@ frappe.ui.form.on('Compliance Sub Category', {
 		  frm.clear_table('compliance_executive');
 		  frm.refresh_field('compliance_executive');
 		}
-	  }
+  }
 });
 
 let create_project_dialog = function(frm){


### PR DESCRIPTION
## Feature description
Update the item when change in Compliance sub category.

## Solution description
If the subcategory is enabled/disabled/deleted, the item should also enabled/disabled/deleted. If subcategory is changed, then the item is get changed. Also the name of the doctype is changed.

## Output screenshots
![image](https://github.com/efeone/one_compliance/assets/84098652/740eb095-1dc2-427c-9152-69f34198f7ba)
![image](https://github.com/efeone/one_compliance/assets/84098652/a43e9c94-1c7e-4ca0-be2b-dda3215e8342)


## Areas affected and ensured
compliance_sub_category.js and compliance_sub_category.py is affected and ensured.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome