### PR TITLE
feat:made the fields read only in sales invoice

### DIFF
--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -36,7 +36,8 @@ doctype_js = {
         "Task": "public/js/task.js",
         "Department": "public/js/department.js",
         "Lead":"public/js/lead.js",
-        "Opportunity":"public/js/opportunity.js"
+        "Opportunity":"public/js/opportunity.js",
+        "Sales Invoice":"public/js/sales_invoice.js"
         }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/one_compliance/public/js/sales_invoice.js
+++ b/one_compliance/public/js/sales_invoice.js
@@ -1,0 +1,25 @@
+frappe.ui.form.on('Sales Invoice', {
+    refresh: function(frm) {
+        if (frm.doc.workflow_state == 'Proforma Invoice') {
+            frm.set_df_property('customer', 'read_only', 1);
+                  frm.set_df_property('is_pos', 'read_only', 1);
+                  frm.set_df_property('is_return', 'read_only', 1);
+                    frm.set_df_property('is_debit_note', 'read_only', 1);
+                      frm.set_df_property('scan_barcode', 'read_only', 1);
+                        frm.set_df_property('update_stock', 'read_only', 1);
+                          frm.set_df_property('project', 'read_only', 1);
+                            frm.set_df_property('cost_center', 'read_only', 1);
+                              frm.set_df_property('items', 'read_only', 1);
+                              frm.set_df_property('tax_category', 'read_only', 1);
+                              frm.set_df_property('taxes', 'read_only', 1);
+                              frm.set_df_property('shipping_rule', 'read_only', 1);
+                                frm.set_df_property('incoterm', 'read_only', 1);
+                                  frm.set_df_property('use_company_roundoff_cost_center', 'read_only', 1);
+                                    frm.set_df_property('disable_rounded_total', 'read_only', 1);
+                                      frm.set_df_property('allocate_advances_automatically', 'read_only', 1);
+                                        frm.set_df_property('get_advances', 'read_only', 1);
+                                          frm.set_df_property('apply_discount_on', 'read_only', 1);
+                                          frm.set_df_property('taxes_and_charges', 'read_only', 1);
+        }
+    }
+});


### PR DESCRIPTION
## Feature description
When the workflow state is 'Proforma Invoice,' the fields, including 'customer,' 'item table,' etc., in the Sales Invoice doctype, are set to read-only.

## Solution description
-Identify Workflow State:
The solution begins by identifying the workflow state of the Sales Invoice.
-Check Workflow State:
Check if the workflow state is 'Proforma Invoice' .
-Determine Fields to be Read-Only:
Identify the specific fields, such as 'customer' and 'item table,' that need to be set to read-only.

## Output screenshots (optional)
[Screencast from 14-12-23 11:27:56 AM IST.webm](https://github.com/efeone/one_compliance/assets/84180042/a43ed29e-02c2-4289-8606-6f43c7abb8ee)


## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?

  - Mozilla Firefox
