### PR TITLE
feat:added a create button in customer and make payment entry.

### DIFF
--- a/one_compliance/one_compliance/doc_events/customer.py
+++ b/one_compliance/one_compliance/doc_events/customer.py
@@ -46,6 +46,32 @@ def create_agreement_custom_button(source_name, target_doc = None):
     return doc
 
 @frappe.whitelist()
+def create_project_custom_button(source_name, target_doc = None):
+    def set_missing_values(source, target):
+        target.customer_name= source.customer_name
+        target.lead_name = source.lead_name
+        target.opportunity_name= source.opportunity_name
+    doc = get_mapped_doc(
+        'Customer',
+        source_name,
+        {
+        'Customer': {
+        'doctype': 'Project',
+        },
+        },target_doc,set_missing_values)
+    return doc
+
+@frappe.whitelist()
+def create_payment_entry(mode_of_payment, paid_amount, customer):
+    new_pe_doc = frappe.new_doc('Payment Entry')
+    new_pe_doc.party_type = 'Customer'
+    new_pe_doc.party = customer
+    new_pe_doc.mode_of_payment = mode_of_payment
+    new_pe_doc.paid_amount = paid_amount
+    new_pe_doc.save()
+    return new_pe_doc.name
+
+@frappe.whitelist()
 def filter_contact(doctype, txt, searchfield, start, page_len, filters):
     '''
         Method used to filter contact
@@ -95,6 +121,20 @@ def custom_button_for_view_compliance_agreement(customer):
     if frappe.db.exists('Compliance Agreement', {'customer':customer, 'status':'Active'}):
         compliance_agreement = frappe.db.get_value('Compliance Agreement', {'customer':customer, 'status':'Active'})
         return compliance_agreement
+    else:
+        return 0
+
+@frappe.whitelist()
+def custom_button_for_view_project(customer):
+    if frappe.db.exists('Project', {'customer':customer}):
+        return 1
+    else:
+        return 0
+
+@frappe.whitelist()
+def custom_button_for_view_payment(party_type, party):
+    if frappe.db.exists('Payment Entry', {'party_type':party_type, 'party':party}):
+        return 1
     else:
         return 0
 

--- a/one_compliance/public/js/customer.js
+++ b/one_compliance/public/js/customer.js
@@ -31,6 +31,8 @@ frappe.ui.form.on('Customer',{
       });
     }
     view_compliance_agreemet(frm)
+    view_project(frm)
+    view_payment_entry(frm)
     }
     // Create sales invoice against compliance_agreement
 
@@ -194,19 +196,72 @@ let view_compliance_agreemet = function(frm) {
      if(r.message){
        frm.add_custom_button('View Agreement', ()=>{
          frappe.set_route('Form','Compliance Agreement', r.message)
-      })
+      }, __('Create'))
      }
      else{
-       frm.add_custom_button('Create Agreement', () => { /* Add a custom button to get compliance agreement details */
+       frm.add_custom_button('Agreement', () => { /* Add a custom button to get compliance agreement details */
          frappe.model.open_mapped_doc({
            method: 'one_compliance.one_compliance.doc_events.customer.create_agreement_custom_button',
            frm: cur_frm
          });
-       });
+       }, __('Create'));
       }
      }
  })
 }
+let view_project = function(frm) {
+  frappe.call({
+    method : 'one_compliance.one_compliance.doc_events.customer.custom_button_for_view_project',
+    args :{
+      'customer' : frm.doc.name
+     },
+     callback : function(r){
+       if(r.message){
+         frm.add_custom_button('Consultant Project', ()=>{
+           frappe.model.open_mapped_doc({
+             method: 'one_compliance.one_compliance.doc_events.customer.create_project_custom_button',
+             frm: cur_frm
+           });
+         }, __('Create'));
+       }
+}
+})
+}
+let view_payment_entry = function(frm) {
+  frm.add_custom_button('Payment', () => {
+    let d = new frappe.ui.Dialog({
+      title: 'Enter Details',
+      fields: [
+        {
+          label: 'Mode of Payment',
+          fieldname: 'mode_of_payment',
+          fieldtype: 'Link',
+          reqd: 1,
+          options: 'Mode of Payment',
+        },
+        {
+          label: 'Paid Amount',
+          fieldname: 'paid_amount',
+          fieldtype: 'Currency',
+          reqd: 1,
+        },
+      ],
+      primary_action_label: 'Create Payment',
+      primary_action(values) {
+        // Use the values directly in the frappe.model.open_mapped_doc
+        frappe.call('one_compliance.one_compliance.doc_events.customer.create_payment_entry', {
+            mode_of_payment: values.mode_of_payment,
+            paid_amount: values.paid_amount,
+            customer: frm.doc.name
+        }).then(r => {
+            console.log(`Payment Entry ${r.message} has been created`)
+        })
+        d.hide();
+      },
+    });
+    d.show();
+  }, __('Create'));
+};
 
 let send_clarification_message = function (frm){
   let d = new frappe.ui.Dialog({


### PR DESCRIPTION
## Feature description
-Add a create button and, add create agreement, create Consultant Project & create payment inside the create button.
-When  click on 'Payment,' a dialog box is displayed, allowing  to enter the mode of payment and paid amount. These entered values are then reflected in the Payment Entry.

## Solution description
-Add "Create" Button
when click on create button shows payment,agreement and consultant project.
-Implement Dialog Box for Payment Entry:
  Inside the button click event, create a dialog box for entering payment details.

## Output screenshots (optional)
![Screenshot from 2023-12-21 14-25-43](https://github.com/efeone/one_compliance/assets/84180042/84d23a22-8418-456f-ab1e-3fae8f628315)
![Screenshot from 2023-12-21 14-26-02](https://github.com/efeone/one_compliance/assets/84180042/ce6081ff-28ee-4df9-8299-1561cc30accb)


## Areas affected and ensured
Customer

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
