### PR TITLE
feat:Engagement Letter Approve Button

### DIFF
--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -138,6 +138,9 @@ doc_events = {
     },
     'Sales Invoice':{
         'on_submit':'one_compliance.one_compliance.doc_events.sales_invoice.sales_invoice_on_submit'
+    },
+    'Opportunity':{
+        'after_save':'one_compliance.one_compliance.doc_events.oppotunity.make_engagement_letter'
     }
 }
 

--- a/one_compliance/one_compliance/doc_events/oppotunity.py
+++ b/one_compliance/one_compliance/doc_events/oppotunity.py
@@ -1,0 +1,22 @@
+import frappe
+from frappe.model.mapper import *
+from frappe import _
+
+@frappe.whitelist()
+def make_engagement_letter(source_name,target_name=None):
+    
+    doclist = get_mapped_doc(
+        "Opportunity",
+        source_name,
+        {
+            "Opportunity": {
+                "doctype": "Engagement Letter",
+                "field_map": {"name": "engagement_letter","engagement_letter_type":"Preliminary analysis & report"},
+                
+            }
+        },
+        target_name
+    )
+
+    
+    return doclist

--- a/one_compliance/one_compliance/doctype/deliverable/deliverable.js
+++ b/one_compliance/one_compliance/doctype/deliverable/deliverable.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Deliverable', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/one_compliance/one_compliance/doctype/deliverable/deliverable.json
+++ b/one_compliance/one_compliance/doctype/deliverable/deliverable.json
@@ -1,0 +1,52 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:deliverables",
+ "creation": "2024-01-08 13:54:27.219198",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "deliverables",
+  "description"
+ ],
+ "fields": [
+  {
+   "fieldname": "deliverables",
+   "fieldtype": "Data",
+   "label": "Deliverables",
+   "unique": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-01-10 14:41:50.262643",
+ "modified_by": "Administrator",
+ "module": "One Compliance",
+ "name": "Deliverable",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_compliance/one_compliance/doctype/deliverable/deliverable.py
+++ b/one_compliance/one_compliance/doctype/deliverable/deliverable.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class Deliverable(Document):
+	pass

--- a/one_compliance/one_compliance/doctype/deliverable/test_deliverable.py
+++ b/one_compliance/one_compliance/doctype/deliverable/test_deliverable.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestDeliverable(FrappeTestCase):
+	pass

--- a/one_compliance/one_compliance/doctype/engagement_letter/engagement_letter.js
+++ b/one_compliance/one_compliance/doctype/engagement_letter/engagement_letter.js
@@ -14,10 +14,21 @@ frappe.ui.form.on('Engagement Letter', {
         if (!frm.doc.__islocal) {
             // Form has been saved, add the custom button
             frm.add_custom_button(__('Approve'), function () {
-                frm.trigger("make_customer");
-                frm.trigger("make_project");
+                if (frm.doc.engagement_letter_types === 'Consulting Engagement Letter') {
+                    // Execute make_customer and make_project only for Consulting Engagement Letter
+                    frm.trigger("make_customer");
+                    frm.trigger("make_project");
+                }
+                else if(frm.doc.engagement_letter_types === 'Preliminary analysis & report') {
+                    frm.set_value('engagement_letter_types', 'Consulting Engagement Letter');
+                    frm.trigger("create_engagement_letter");
+                    
+                }
+                
+                
             });
         }
+
     },
     make_customer: function (frm) {
         frappe.call({
@@ -41,25 +52,14 @@ frappe.ui.form.on('Engagement Letter', {
             frm: cur_frm
         });
     },
-    lead: function (frm) {
-        if (frm.doc.lead) {
-            frappe.call({
-                method: 'frappe.client.get_value',
-                args: {
-                    doctype: 'Lead',
-                    filters: { name: frm.doc.lead },
-                    fieldname: ['lead_name', 'email_id', 'mobile_no']
-                },
-                callback: function (r) {
-                    if (r.message) {
-                        frm.set_value('full_name', r.message.lead_name);
-                        frm.set_value('email', r.message.email_id);
-                        frm.set_value('mobile', r.message.mobile_no);
-                    }
-                }
-            });
-        }
+    create_engagement_letter: function (frm) {
+
+        frappe.model.open_mapped_doc({
+            method: 'one_compliance.one_compliance.doctype.engagement_letter.engagement_letter.create_engagement_letter',
+            frm: cur_frm
+        });
     },
+    
     opportunity: function (frm) {
         if (frm.doc.opportunity) {
             frappe.call({

--- a/one_compliance/one_compliance/doctype/engagement_letter/engagement_letter.json
+++ b/one_compliance/one_compliance/doctype/engagement_letter/engagement_letter.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "field:full_name",
+ "autoname": "format:{full_name}-{engagement_letter_types}",
  "creation": "2023-10-31 16:45:45.648733",
  "default_view": "List",
  "doctype": "DocType",
@@ -74,14 +74,15 @@
   "working_team_section",
   "working_team",
   "employees",
-  "project_name"
+  "project"
  ],
  "fields": [
   {
+   "depends_on": "eval: doc.engagement_letter_types == \"Consulting Engagement Letter\"",
+   "fetch_from": "opportunity.contact_person",
    "fieldname": "full_name",
    "fieldtype": "Data",
-   "label": "Full Name",
-   "unique": 1
+   "label": "Full Name"
   },
   {
    "fieldname": "opportunity",
@@ -172,14 +173,13 @@
    "fieldname": "posting_date",
    "fieldtype": "Date",
    "in_list_view": 1,
-   "label": "Date",
-   "reqd": 1
+   "label": "Date"
   },
   {
    "fieldname": "engagement_letter_types",
    "fieldtype": "Select",
    "label": "Engagement Letter types",
-   "options": "\nPreliminary analysis & report\nConsulting Engagement Letter"
+   "options": "Preliminary analysis & report\nConsulting Engagement Letter"
   },
   {
    "depends_on": "eval: doc.engagement_letter_types == \"Consulting Engagement Letter\"",
@@ -424,10 +424,10 @@
    "label": "Territory"
   },
   {
-   "fetch_from": "opportunity.customer_group",
    "fieldname": "customer_group",
-   "fieldtype": "Data",
-   "label": "Customer Group"
+   "fieldtype": "Link",
+   "label": "Customer Group",
+   "options": "Customer Group"
   },
   {
    "default": "Company",
@@ -438,18 +438,19 @@
    "reqd": 1
   },
   {
-   "fieldname": "project_name",
-   "fieldtype": "Data",
-   "label": "Project Name"
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-12-21 09:35:03.112486",
+ "modified": "2024-01-11 15:32:06.238417",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Engagement Letter",
- "naming_rule": "By fieldname",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/one_compliance/one_compliance/doctype/engagement_letter/engagement_letter.py
+++ b/one_compliance/one_compliance/doctype/engagement_letter/engagement_letter.py
@@ -38,6 +38,28 @@ def get_working_team(employee_group):
 
 
 @frappe.whitelist()
+def create_engagement_letter(source_name,target_doc=None):
+
+    def set_missing_values(source, target):
+        target.engagement_letter_types = 'Consulting Engagement Letter'
+    
+    doc = get_mapped_doc(
+        "Engagement Letter",
+        source_name,
+        {
+            "Engagement Letter": {
+                "doctype": "Engagement Letter",
+                "field_map": {
+                    "name": "engagement_letter",
+                },
+            }
+        },
+        target_doc,
+        set_missing_values
+    )
+    return doc
+
+@frappe.whitelist()
 def make_project(source_name,target_name=None):
     
     doclist = get_mapped_doc(
@@ -54,6 +76,5 @@ def make_project(source_name,target_name=None):
 
     
     return doclist
-
 
 

--- a/one_compliance/public/js/opportunity.js
+++ b/one_compliance/public/js/opportunity.js
@@ -7,5 +7,16 @@ frappe.ui.form.on('Opportunity',{
               frm.remove_custom_button('Request For Quotation','Create')
               })
         }
-    }
+        
+        frm.add_custom_button(__('Engagement Letter'), function () {
+            frm.trigger("make_engagement_letter");
+        },__("Create"));
+    
+    },
+    make_engagement_letter: function (frm) {
+        frappe.model.open_mapped_doc({
+            method: 'one_compliance.one_compliance.doc_events.oppotunity.make_engagement_letter',
+            frm: cur_frm
+        });
+    },
 });


### PR DESCRIPTION
## Feature description

- Create an 'Engagement Letter' button in Opportunity.
- Create an Engagement Letter with the engagement letter type set to 'Consulting Engagement Letter' by clicking the 'Approve' button in an Engagement Letter with the engagement letter type set to 'Preliminary Analysis & Report.'
- After clicking the 'Approve' button in the Engagement Letter with the engagement letter type set as 'Consulting Engagement Letter,' a project and customer are created.

## Output screenshots (optional)
![image](https://github.com/efeone/one_compliance/assets/84179426/f4dde881-e02b-44c1-a474-2cb96d3a39a7)
![image](https://github.com/efeone/one_compliance/assets/84179426/768996a5-7e3d-4f8f-8991-dc0e74bb0fb4)
![image](https://github.com/efeone/one_compliance/assets/84179426/7b279f58-0b0c-41e0-b71c-edd51332e20f)
![image](https://github.com/efeone/one_compliance/assets/84179426/79643edd-ee90-43be-8fac-ce43fcd2f88b)



## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
