### PR TITLE
feat:fetch from date and to date from reference docname

### DIFF
--- a/one_compliance/one_compliance/doctype/assessment_year/assessment_year.json
+++ b/one_compliance/one_compliance/doctype/assessment_year/assessment_year.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "field:assessment_year",
  "creation": "2024-01-16 15:02:16.932940",
  "default_view": "List",
  "doctype": "DocType",
@@ -8,38 +9,57 @@
  "engine": "InnoDB",
  "field_order": [
   "assessment_year",
-  "start_date",
-  "end_date"
+  "year_start_date",
+  "column_break_qzadw",
+  "year_end_date"
  ],
  "fields": [
   {
-   "fieldname": "start_date",
+   "fieldname": "assessment_year",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Assessment Year Name",
+   "unique": 1
+  },
+  {
+   "fieldname": "column_break_qzadw",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "year_start_date",
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "From Date"
   },
   {
-   "fieldname": "end_date",
+   "fieldname": "year_end_date",
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "To Date"
-  },
-  {
-   "fieldname": "assessment_year",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Assessment Year Name"
   }
  ],
  "index_web_pages_for_search": 1,
- "istable": 1,
  "links": [],
- "modified": "2024-01-16 15:02:45.883197",
+ "modified": "2024-01-18 16:14:55.641182",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Assessment Year",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
- "permissions": [],
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/one_compliance/one_compliance/doctype/project_name_year_type/project_name_year_type.js
+++ b/one_compliance/one_compliance/doctype/project_name_year_type/project_name_year_type.js
@@ -2,7 +2,23 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Project Name Year Type', {
-	// refresh: function(frm) {
-
-	// }
+	
+reference_docname: function (frm) {
+        frappe.call({
+            method: 'one_compliance.one_compliance.doctype.project_name_year_type.project_name_year_type.get_reference_doctype',
+            args: {
+                reference_doctype: frm.doc.reference_doctype,
+                reference_docname: frm.doc.reference_docname
+            },
+            callback: function (r) {
+                if (r.message) {
+                    // Access the fetched document using r.message
+                    var doc = r.message;
+                    // Perform actions based on the fetched document
+                    frm.set_value('from_date', doc.from_date);
+                    frm.set_value('to_date', doc.to_date);
+                }
+            }
+        });
+    }
 });

--- a/one_compliance/one_compliance/doctype/project_name_year_type/project_name_year_type.json
+++ b/one_compliance/one_compliance/doctype/project_name_year_type/project_name_year_type.json
@@ -9,8 +9,10 @@
  "engine": "InnoDB",
  "field_order": [
   "type_name",
+  "section_break_adppb",
   "reference_doctype",
   "reference_docname",
+  "column_break_uho00",
   "from_date",
   "to_date"
  ],
@@ -42,11 +44,19 @@
    "fieldtype": "Dynamic Link",
    "label": "Reference DocName",
    "options": "reference_doctype"
+  },
+  {
+   "fieldname": "section_break_adppb",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_uho00",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-01-16 16:26:54.546864",
+ "modified": "2024-01-17 15:08:09.451845",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Project Name Year Type",

--- a/one_compliance/one_compliance/doctype/project_name_year_type/project_name_year_type.py
+++ b/one_compliance/one_compliance/doctype/project_name_year_type/project_name_year_type.py
@@ -1,8 +1,20 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 class ProjectNameYearType(Document):
 	pass
+
+@frappe.whitelist()
+def get_reference_doctype(reference_doctype,reference_docname):
+    """
+    Fetch the complete document based on the provided reference doctype and docname.
+    """
+    doc = frappe.get_doc(reference_doctype, reference_docname)
+
+    return {
+        'from_date': doc.year_start_date,
+        'to_date': doc.year_end_date,
+    }

--- a/one_compliance/one_compliance/doctype/project_naming_years/project_naming_years.json
+++ b/one_compliance/one_compliance/doctype/project_naming_years/project_naming_years.json
@@ -36,7 +36,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-01-17 09:42:21.178963",
+ "modified": "2024-01-17 15:13:00.216222",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Project Naming Years",


### PR DESCRIPTION
## Feature description
Fetch 'From Date' and 'To Date' in the 'Project Name Year Type' when the reference docname is provided; automatically retrieve the 'From Date' and 'To Date' based on the given reference docname.

## Solution description
Retrieve the 'From Date' and 'To Date' from the 'Assessment Year' and 'Fiscal Year' based on the provided reference docname.

## Output 
[Screencast from 18-01-24 04:31:34 PM IST.webm](https://github.com/efeone/one_compliance/assets/84180042/3b3d77f0-acaa-45d0-836f-cffccee9e693)
## Areas affected and ensured
Compliance Setting
## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
