### PR TITLE
Start timer

### DIFF
--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.css
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.css
@@ -1,11 +1,11 @@
 .card {
         margin: 10px;
         box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-        border: 1px solid #ddd;
+        border: None;
         border-radius: 8px;
         overflow: hidden;
         padding: 2px;
-        background-color: #fff3ff;
+        background-color: aliceblue;
     }
 
     .layout-main-section.frappe-card {
@@ -16,12 +16,6 @@
       background-color: #fdf7f9;
     }
 
-    .form-control.input-xs{
-      background-color: aliceblue;
-    }
-    .awesomplete .input-with-feedback {
-      background-color: aliceblue;
-    }
     .card-body {
         padding: 20px;
     }

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.css
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.css
@@ -36,6 +36,7 @@
     .btn-icon {
         margin-right: 2px;
         padding: 8px;
+        margin-bottom: 5px;
     }
 
     .rounded-circle {

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.html
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.html
@@ -2,7 +2,7 @@
 <div class="row header-row task-entry" style="margin-top:5px;">
     <div class="col-md-2 text-center">Task</div>
     <div class="col-md-2 text-center">Start - End Date</div>
-    <div class="col-md-2 text-center">Compliance Category</div>
+    <div class="col-md-2 text-center">Department</div>
     <div class="col-md-2 text-center">Compliance Sub Category</div>
     <div class="col-md-2 text-center assignee-section">Assigned To</div>
     <div class="col-md-2 text-center completed-by-section">Completed By</div>
@@ -24,8 +24,8 @@
                 <div class="col-md-2 text-center" style="padding: inherit;">
                     {{ data.exp_start_date }} <br>- {{ data.exp_end_date }}
                 </div>
-                <a class="col-md-2 text-center" style="padding: inherit;" href="/app/compliance-category/{{ data.compliance_category }}">
-                    {{ data.compliance_category }}
+                <a class="col-md-2 text-center" style="padding: inherit;" href="/app/department/{{ data.department }}">
+                    {{ data.department }}
                 </a>
                 <a class="col-md-2 text-center" style="padding: inherit;" href="/app/compliance-sub-category/{{ data.compliance_sub_category }}">
                     {{ data.compliance_sub_category }}
@@ -49,6 +49,10 @@
                   {{ data.status }}
                 </div>
                 <div class="col-md-1" style="padding: inherit;">
+                    <p class="start-time" task-id="{{ data.name }}" project-id="{{ data.project }}" ></p>
+                    <button class="btn btn-outline-warning btn-icon startButton" task-id="{{ data.name }}" project-id="{{ data.project }}" data-toggle="tooltip" title="Start Timer">
+                        <i class="fas fa-play"></i>
+                    </button>
                     <button class="btn btn-outline-primary btn-icon timeEntryButton" task-id="{{ data.name }}" project-id="{{ data.project }}" assignees="{{ data.employee_names }}" data-toggle="tooltip" title="Time Sheet">
                         <i class="fas fa-clock"></i>
                     </button>

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.html
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.html
@@ -4,7 +4,8 @@
     <div class="col-md-2 text-center">Start - End Date</div>
     <div class="col-md-2 text-center">Compliance Category</div>
     <div class="col-md-2 text-center">Compliance Sub Category</div>
-    <div class="col-md-2 text-center">Assignee</div>
+    <div class="col-md-2 text-center assignee-section">Assigned To</div>
+    <div class="col-md-2 text-center completed-by-section">Completed By</div>
     <div class="col-md-2">Status</div>
 </div>
 {% for data in task_list %}
@@ -30,7 +31,7 @@
                     {{ data.compliance_sub_category }}
                 </a>
                 <div class="col-md-2 text-center" style="padding: inherit; position:relative;">
-                    <p class="card-text">
+                    <p class="card-text assignee-section">
                         {% if data._assign %}
                             {% for assignee in data._assign %}
                                 <a href="/app/employee/{{ assignee.employee_id }}">{{ assignee.employee_name }}</a><br>
@@ -39,6 +40,9 @@
                         <button class="btn btn-sm rounded-circle addAssigneeBtn" task-id="{{ data.name }}">
                             <i class="fas fa-plus"></i>
                         </button>
+                    </p>
+                    <p class="card-text completed-by-section">
+                        <a href="/app/employee/{{ data.completed_by_id }}" style="padding-left: 15px;">{{ data.completed_by_name }}</a><br>
                     </p>
                 </div>
                 <div class="col-md-1 text-center" style="padding: inherit;" status-span="{{ data.status }}" task-name="{{ data.subject }}" project-id="{{ data.project }}" task-id="{{ data.name }}" is-payable="{{ data.is_payable }}">

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
@@ -8,7 +8,7 @@ def get_task(status = None, task = None, project = None, customer = None, catego
 
     query = """
 	SELECT
-        t.name,t.project,t.subject, t.project_name, t.customer, c.compliance_category, t.compliance_sub_category, t.exp_start_date, t.exp_end_date, t._assign, t.status, t.assigned_to
+        t.name,t.project,t.subject, t.project_name, t.customer, c.compliance_category, t.compliance_sub_category, t.exp_start_date, t.exp_end_date, t._assign, t.status, t.assigned_to, t.completed_by
     FROM
         tabTask t JOIN `tabCompliance Sub Category` c ON t.compliance_sub_category = c.name
     """
@@ -45,8 +45,6 @@ def get_task(status = None, task = None, project = None, customer = None, catego
 
     query += ";"
 
-    print(query)
-
     task_list = frappe.db.sql(query, as_dict=1)
     for task in task_list:
         task['employee_names'] = []
@@ -68,6 +66,17 @@ def get_task(status = None, task = None, project = None, customer = None, catego
         else:
             task['_assign'] = []
             task['employee_names'] = []
+
+        if task['completed_by']:
+            if task['completed_by'] == 'Administrator':
+                task['completed_by_name'] = 'Administrator'
+            else:
+                completed_by = frappe.get_value("Employee", {"user_id": task['completed_by']}, ["name", "employee_name"], as_dict=True)
+                task['completed_by_name'] = completed_by["employee_name"]
+                task['completed_by_id'] = completed_by["name"]
+        else:
+            task['completed_by_name'] = []
+            task['completed_by_id'] = []
 
         task['is_payable'] = check_payable_task(task['subject'])
     return task_list

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
@@ -2,13 +2,13 @@ import frappe
 from frappe.utils import get_datetime
 
 @frappe.whitelist()
-def get_task(status = None, task = None, project = None, customer = None, category = None, sub_category = None, employee = None, employee_group = None, from_date = None, to_date = None):
+def get_task(status = None, task = None, project = None, customer = None, department = None, sub_category = None, employee = None, employee_group = None, from_date = None, to_date = None):
 
     user_id = f'"{employee}"' if id else None
 
     query = """
 	SELECT
-        t.name,t.project,t.subject, t.project_name, t.customer, c.compliance_category, t.compliance_sub_category, t.exp_start_date, t.exp_end_date, t._assign, t.status, t.assigned_to, t.completed_by
+        t.name,t.project,t.subject, t.project_name, t.customer, c.department, t.compliance_sub_category, t.exp_start_date, t.exp_end_date, t._assign, t.status, t.assigned_to, t.completed_by
     FROM
         tabTask t JOIN `tabCompliance Sub Category` c ON t.compliance_sub_category = c.name
     """
@@ -25,8 +25,8 @@ def get_task(status = None, task = None, project = None, customer = None, catego
     if customer:
             query += f" AND t.customer = '{customer}'"
 
-    if category:
-            query += f" AND c.compliance_category = '{category}'"
+    if department:
+            query += f" AND c.department = '{department}'"
 
     if sub_category:
             query += f" AND t.compliance_sub_category = '{sub_category}'"

--- a/one_compliance/one_compliance/workspace/one_compliance/one_compliance.json
+++ b/one_compliance/one_compliance/workspace/one_compliance/one_compliance.json
@@ -1,6 +1,6 @@
 {
  "charts": [],
- "content": "[{\"id\":\"5BUXDiF8R0\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">One Compliance</span>\",\"col\":12}},{\"id\":\"HEmaEhp7ie\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Lead\",\"col\":3}},{\"id\":\"mhhZEA8cvN\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Opportunity\",\"col\":3}},{\"id\":\"oh2ffefeQz\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Customer\",\"col\":3}},{\"id\":\"ERgvpoLwFk\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Compliance Category\",\"col\":3}},{\"id\":\"_88kEmzxfQ\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Compliance Sub Category\",\"col\":3}},{\"id\":\"sL4M8ll55x\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Project Template\",\"col\":3}},{\"id\":\"WCuSG8lodn\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Compliance Agreement\",\"col\":3}},{\"id\":\"nn2D2Ro6cI\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Inward Register\",\"col\":3}},{\"id\":\"gH03a8MVtf\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Outward Register\",\"col\":3}},{\"id\":\"se8gAdDVTb\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Project\",\"col\":3}},{\"id\":\"gEkzPviwCg\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Compliance Settings\",\"col\":3}},{\"id\":\"R8QyqA6czU\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Notification Template\",\"col\":3}},{\"id\":\"fOvE7-NEN-\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Purpose\",\"col\":3}},{\"id\":\"gaS6YNkmz5\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Customer Credentials\",\"col\":3}},{\"id\":\"p1oNkqOyYf\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Credential Type\",\"col\":3}},{\"id\":\"NTuP9AIB6R\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Customer Document\",\"col\":3}},{\"id\":\"ljx0qdyTGh\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Dashboard\",\"col\":3}},{\"id\":\"4LNINgA53i\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Task Bulk Assignment\",\"col\":3}}]",
+ "content": "[{\"id\":\"5BUXDiF8R0\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">One Compliance</span>\",\"col\":12}},{\"id\":\"HEmaEhp7ie\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Lead\",\"col\":3}},{\"id\":\"mhhZEA8cvN\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Opportunity\",\"col\":3}},{\"id\":\"oh2ffefeQz\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Customer\",\"col\":3}},{\"id\":\"ERgvpoLwFk\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Compliance Category\",\"col\":3}},{\"id\":\"_88kEmzxfQ\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Compliance Sub Category\",\"col\":3}},{\"id\":\"sL4M8ll55x\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Project Template\",\"col\":3}},{\"id\":\"WCuSG8lodn\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Compliance Agreement\",\"col\":3}},{\"id\":\"nn2D2Ro6cI\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Inward Register\",\"col\":3}},{\"id\":\"gH03a8MVtf\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Outward Register\",\"col\":3}},{\"id\":\"se8gAdDVTb\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Project\",\"col\":3}},{\"id\":\"gEkzPviwCg\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Compliance Settings\",\"col\":3}},{\"id\":\"R8QyqA6czU\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Notification Template\",\"col\":3}},{\"id\":\"fOvE7-NEN-\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Purpose\",\"col\":3}},{\"id\":\"gaS6YNkmz5\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Customer Credentials\",\"col\":3}},{\"id\":\"p1oNkqOyYf\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Credential Type\",\"col\":3}},{\"id\":\"NTuP9AIB6R\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Customer Document\",\"col\":3}},{\"id\":\"ljx0qdyTGh\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Dashboard\",\"col\":3}},{\"id\":\"4LNINgA53i\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Task Bulk Assignment\",\"col\":3}},{\"id\":\"4H6utfMDZB\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Task Management Tool\",\"col\":3}}]",
  "creation": "2023-03-13 11:15:00.910081",
  "custom_blocks": [],
  "docstatus": 0,
@@ -12,7 +12,7 @@
  "is_hidden": 0,
  "label": "One Compliance",
  "links": [],
- "modified": "2024-01-08 16:36:53.333853",
+ "modified": "2024-01-24 12:13:55.151149",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "One Compliance",
@@ -30,6 +30,13 @@
    "label": "Task Bulk Assignment",
    "link_to": "Task Bulk Assignment",
    "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Task Management Tool",
+   "link_to": "task-management-tool",
+   "type": "Page"
   },
   {
    "color": "Grey",


### PR DESCRIPTION
## Feature description
Set timer for timesheet with start_time and end_time

## Solution description
Implemented a start timer button. Upon clicking set a from_time that set to the from_time field of dialog box in the timesheet.
Set the to_date as now_datetime when clicking the button for timesheet button.

## Output screenshots
![image](https://github.com/efeone/one_compliance/assets/84098652/400812a4-6cc5-4209-8766-8932a08e4f52)

## Areas affected and ensured
task_management_tool.js, task_management_tool.py and task_management_tool.html are affected and ensured.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome