### PR TITLE
feat:reverse the compliance agreement

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.js
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.js
@@ -44,6 +44,11 @@ frappe.ui.form.on('Compliance Agreement', {
     });
 
     if (!frm.is_new()) {
+      if (frm.doc.workflow_state != 'Cancelled' && frm.doc.workflow_state != 'Reverse') {
+          frm.add_custom_button('Reverse', () => {
+              reverseFunction(frm);
+          });
+      }
       frm.add_custom_button('Set Agreement Status', () => {
         set_agreement_status(frm)
       })
@@ -175,6 +180,20 @@ let set_agreement_status = function (frm) {
     }
   });
   d.show();
+}
+
+let reverseFunction = function(frm){
+    frappe.call({
+        method: 'one_compliance.one_compliance.doctype.compliance_agreement.compliance_agreement.reverse_function',
+        args: {
+            docname: frm.doc.name
+        },
+        callback: function(response) {
+            if (response.message) {
+                frappe.set_route('Form', 'Compliance Agreement', response.message);
+            }
+        }
+    });
 }
 
 let create_project = function (frm) {

--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.json
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.json
@@ -17,6 +17,7 @@
   "invoice_based_on",
   "invoice_generation",
   "column_break_czvvr",
+  "disabled",
   "lead_name",
   "opportunity_name",
   "has_long_term_validity",
@@ -175,8 +176,9 @@
    "allow_on_submit": 1,
    "fieldname": "status",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Status",
-   "options": "Open\nActive\nExpired\nHold\nCancelled",
+   "options": "Open\nActive\nExpired\nHold\nCancelled\nReverse",
    "read_only": 1
   },
   {
@@ -233,12 +235,18 @@
    "fieldname": "next_invoice_date",
    "fieldtype": "Date",
    "label": "Invoice End Date"
+  },
+  {
+   "default": "0",
+   "fieldname": "disabled",
+   "fieldtype": "Check",
+   "label": "Disabled"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-01-05 12:33:54.501190",
+ "modified": "2024-01-29 13:11:12.819272",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Compliance Agreement",

--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
@@ -458,3 +458,63 @@ def get_rate_from_compliance_agreement(compliance_agreement, compliance_sub_cate
         )
     if rate_result:
         return rate_result[0].rate
+
+
+@frappe.whitelist()
+def reverse_function(docname):
+    current_doc = frappe.get_doc('Compliance Agreement', docname)
+
+    # Retrieve child table data
+    child_table_data = frappe.get_all("Compliance Category Details",
+                                       filters={'parent': docname},
+                                       fields=['compliance_category', 'compliance_date', 'sub_category_name', 'next_compliance_date', 'rate'])
+    print(child_table_data)
+
+    # Check if there are any compliance dates in the current agreement
+    has_compliance_dates = any(row.get("compliance_date") and row.get("next_compliance_date") for row in child_table_data)
+
+    if not has_compliance_dates:
+        frappe.msgprint(_("Cannot reverse without recurring task."), alert=True)
+        return
+
+    # Create a new compliance agreement
+    new_doc = frappe.new_doc("Compliance Agreement")
+
+    # Copy all values from the current agreement to the new one
+    new_doc.update(current_doc.as_dict())
+
+    # Set the valid from date to the reverse date
+    new_doc.valid_from = frappe.utils.now_datetime()
+    new_doc.valid_upto = current_doc.valid_upto
+    new_doc.has_long_term_validity = current_doc.has_long_term_validity
+    new_doc.customer = current_doc.customer
+    new_doc.invoice_based_on = current_doc.invoice_based_on
+    new_doc.compliance_category = current_doc.compliance_category
+
+    # Filter out rows with both compliance_date and next_compliance_date as none
+    new_doc.compliance_category_details = []
+
+    for row in child_table_data:
+        if row.get("compliance_date") or row.get("next_compliance_date"):
+            new_row = new_doc.append("compliance_category_details", {})
+            new_row.compliance_category = row.get("compliance_category")
+            new_row.compliance_date = row.get("compliance_date")
+            new_row.sub_category_name = row.get("sub_category_name")
+            new_row.next_compliance_date = row.get("next_compliance_date")
+            new_row.rate = row.get("rate")
+
+    new_doc.workflow_state = 'Draft'
+    new_doc.docstatus = 0  # Set the document status to 'Draft'
+
+    # Save the new compliance agreement
+    new_doc.insert(ignore_permissions=True)
+
+    frappe.msgprint(_("Compliance Agreement reversed successfully."), alert=True)
+
+    # Check if the "disabled" field is not checked
+    if current_doc.disabled == 0:
+        # Set the disabled is 1 and status to "Reverse"
+        frappe.db.set_value('Compliance Agreement', docname, 'disabled', 1)
+        frappe.db.set_value('Compliance Agreement', docname, 'workflow_state', 'Reverse')
+
+    return new_doc.name


### PR DESCRIPTION
## Feature description
1.In compliance agreement add a button 'Reverse'.
2.When click on Reverse Button Create a new agreement in draft mode with  Reverse all the recurring tasks.
3. Set valid from as present date, valid to as same the the reversing agreement,
4. Status has to be 'reverse' and old agreement must be 'disabled'.
5. Hide the reverse button in cancelled and reverse agreement.

## Solution description
Add a custom button with the label 'Reverse' .
When the 'Reverse' button is clicked, retrieve all recurring tasks associated with the current compliance agreement.
Set the valid from date of the new compliance agreement to the current date.
Set the status of the new compliance agreement to 'Reverse'.
Check the 'Disable' in old agreement

## Output screenshots (optional)

![Screenshot from 2024-01-30 11-42-26](https://github.com/efeone/one_compliance/assets/84180042/271f938f-6d7e-4d28-adba-5c1ba0de03af)
![Screenshot from 2024-01-30 11-49-26](https://github.com/efeone/one_compliance/assets/84180042/9e62a161-80d3-45b8-901c-93b838d68aab)



## Areas affected and ensured
Compliance Agreement

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox

