### PR TITLE
feat: Button for update compliance date

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.js
+++ b/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.js
@@ -8,6 +8,11 @@ frappe.ui.form.on('Compliance Settings', {
         create_projects_manually_perticular_date(frm)
       })
     }
+		if (frappe.session.user == "Administrator"){
+      frm.add_custom_button('Change Compliance Date', () => {
+        change_perticular_compliance_date(frm)
+      })
+    }
     //filter for task_before_due_date_notification based on doctype
     frm.set_query('task_before_due_date_notification', function(){
       return {
@@ -81,7 +86,7 @@ frappe.ui.form.on('Compliance Settings', {
     frm.set_query('default_reimbursement_item', function() {
       return {
         filters: {
-          is_service_item: 1 
+          is_service_item: 1
         }
       };
     });
@@ -89,7 +94,7 @@ frappe.ui.form.on('Compliance Settings', {
 });
 
 let create_projects_manually_perticular_date = function(frm){
-  //function to set the craete of compliance project manually 
+  //function to set the craete of compliance project manually
   let d = new frappe.ui.Dialog({
     title: 'Manual Project Creation',
     fields: [
@@ -121,3 +126,35 @@ let create_projects_manually_perticular_date = function(frm){
   d.show();
 }
 
+let change_perticular_compliance_date = function(frm){
+  //function to change the compliance date manually
+  let d = new frappe.ui.Dialog({
+    title: 'Compliance Date Updation',
+    fields: [
+        {
+            label: 'Compliance Date',
+            fieldname: 'compliance_date',
+            fieldtype: 'Date',
+            reqd: 1
+        },
+    ],
+    primary_action_label: 'Change Compliance Date',
+    primary_action(values) {
+      if(values.compliance_date){
+        frappe.call({
+          method:'one_compliance.one_compliance.doctype.compliance_settings.compliance_settings.compliance_date_update',
+          args:{
+            'compliance_date': values.compliance_date,
+          },
+          callback:function(r){
+            if (r.message) {
+              frm.reload_doc()
+            }
+          }
+        });
+      }
+        d.hide();
+    }
+  });
+  d.show();
+}

--- a/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.py
+++ b/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.py
@@ -29,3 +29,17 @@ def create_project_if_not_exists(self, starting_date):
 					if compliance_category.compliance_date and getdate(compliance_category.compliance_date) == getdate(starting_date):
 						create_project_against_sub_category(self.name, compliance_category.compliance_sub_category, compliance_category.name)
 
+@frappe.whitelist()
+def compliance_date_update(compliance_date):
+	from one_compliance.one_compliance.doctype.compliance_agreement.compliance_agreement import update_compliance_dates
+	projects = frappe.db.get_all('Project',filters = {'expected_start_date': getdate(compliance_date)},fields = ['name','compliance_agreement'])
+	if projects:
+		for project in projects:
+			agreement = frappe.get_doc('Compliance Agreement', project.compliance_agreement)
+			if agreement.status == 'Active' and agreement.workflow_state=='Customer Approved':
+				if agreement.compliance_category_details:
+					for compliance_category in agreement.compliance_category_details:
+						compliance_category_details_id = compliance_category.name
+						if frappe.db.get_value('Compliance Category Details', compliance_category_details_id, 'compliance_date') == getdate(compliance_date):
+							compliance_date = frappe.db.get_value('Compliance Category Details', compliance_category_details_id, 'compliance_date')
+							update_compliance_dates(compliance_category_details_id)


### PR DESCRIPTION
## Feature description
Button for update compliance date manually.

## Solution description
Created a button in Compliance Settings to manually update the compliance date within the compliance agreement for projects that have already been created.

## Output screenshots 
![image](https://github.com/efeone/one_compliance/assets/84098652/b9ac640c-eaa4-4e45-a655-fce1014d5829)

## Areas affected and ensured
compliance_settings.js and compliance_settings.py 

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome
