### PR TITLE
feat:Added compliance agreement field in the update compliance date button

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.js
+++ b/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.js
@@ -137,6 +137,12 @@ let change_perticular_compliance_date = function(frm){
             fieldtype: 'Date',
             reqd: 1
         },
+				{
+						label: 'Compliance Agreement',
+						fieldname: 'compliance_agreement',
+						fieldtype: 'Link',
+						options: 'Compliance Agreement'
+				},
     ],
     primary_action_label: 'Change Compliance Date',
     primary_action(values) {
@@ -145,6 +151,7 @@ let change_perticular_compliance_date = function(frm){
           method:'one_compliance.one_compliance.doctype.compliance_settings.compliance_settings.compliance_date_update',
           args:{
             'compliance_date': values.compliance_date,
+						'compliance_agreement': values.compliance_agreement,
           },
           callback:function(r){
             if (r.message) {

--- a/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.py
+++ b/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.py
@@ -30,9 +30,15 @@ def create_project_if_not_exists(self, starting_date):
 						create_project_against_sub_category(self.name, compliance_category.compliance_sub_category, compliance_category.name)
 
 @frappe.whitelist()
-def compliance_date_update(compliance_date):
+def compliance_date_update(compliance_date, compliance_agreement = None):
 	from one_compliance.one_compliance.doctype.compliance_agreement.compliance_agreement import update_compliance_dates
-	projects = frappe.db.get_all('Project',filters = {'expected_start_date': getdate(compliance_date)},fields = ['name','compliance_agreement'])
+
+	filters = {'expected_start_date': getdate(compliance_date)}
+
+	if compliance_agreement:
+		filters['compliance_agreement'] = compliance_agreement
+
+	projects = frappe.db.get_all('Project',filters = filters, fields = ['name','compliance_agreement'])
 	if projects:
 		for project in projects:
 			agreement = frappe.get_doc('Compliance Agreement', project.compliance_agreement)

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.css
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.css
@@ -12,10 +12,13 @@
       background-color: #fdf7f9;
     }
 
-    .page-form{
+    .page-form {
       background-color: #fdf7f9;
     }
 
+    .list-row-head {
+      background-color: transparent;
+    }
     .card-body {
         padding: 20px;
     }

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.html
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.html
@@ -1,14 +1,19 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
-<div class="row header-row task-entry" style="margin-top:5px;">
-    <div class="col-md-2 text-center">Task</div>
-    <div class="col-md-2 text-center">Start - End Date</div>
-    <div class="col-md-2 text-center">Department</div>
-    <div class="col-md-2 text-center">Compliance Sub Category</div>
-    <div class="col-md-2 text-center assignee-section">Assigned To</div>
-    <div class="col-md-2 text-center completed-by-section">Completed By</div>
-    <div class="col-md-2">Status</div>
-</div>
-{% for data in task_list %}
+<div class="frappe-list">
+  <div class="result">
+    <header class="level list-row-head text-muted">
+      <div class="level-left list-header-subject" style="margin-top:5px;">
+          <div class="col-md-2 text-center">Task</div>
+          <div class="col-md-2 text-center">Start - End Date</div>
+          <div class="col-md-2 text-center">Department</div>
+          <div class="col-md-2 text-center">Compliance Sub Category</div>
+          <div class="col-md-2 text-center assignee-section">Assigned To</div>
+          <div class="col-md-2 text-center completed-by-section">Completed By</div>
+          <div class="col-md-2">Status</div>
+      </div>
+    </header>
+
+    {% for data in task_list %}
     <div class="card task-entry">
         <div class="card-body">
             <div class="row">
@@ -66,4 +71,6 @@
             </div>
         </div>
     </div>
-{% endfor %}
+    {% endfor %}
+  </div>
+</div>

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
@@ -19,27 +19,42 @@ function make_filters(page) {
 		fieldtype: "Link",
 		options: "Task",
 		change() {
-			refresh_tasks(page);
+			if (page.fields_dict.task.get_value()) {
+          refresh_tasks(page);
+      }
 		}
 	});
+	page.fields_dict.task.$input.on('change', function() {
+      refresh_tasks(page);
+  });
 	let projectField = page.add_field({
 		label: __("Project"),
 		fieldname: "project",
 		fieldtype: "Link",
 		options: "Project",
 		change() {
-			refresh_tasks(page);
+			if (page.fields_dict.project.get_value()) {
+          refresh_tasks(page);
+      }
 		}
 	});
+	page.fields_dict.project.$input.on('change', function() {
+      refresh_tasks(page);
+  });
 	let customerField = page.add_field({
 		label: __("Customer"),
 		fieldname: "customer",
 		fieldtype: "Link",
 		options:"Customer",
 		change() {
-			refresh_tasks(page);
+			if (page.fields_dict.customer.get_value()) {
+          refresh_tasks(page);
+      }
 		}
 	});
+	page.fields_dict.customer.$input.on('change', function() {
+      refresh_tasks(page);
+  });
 	let employeeField = page.add_field({
 		label: __("Employee"),
 		fieldname: "employee",
@@ -47,37 +62,57 @@ function make_filters(page) {
 		options: "User",
 		default: get_employee_id(),
 		change() {
-			refresh_tasks(page);
+			if (page.fields_dict.employee.get_value()) {
+          refresh_tasks(page);
+      }
 		},
 		read_only: frappe.session.user === 'Administrator' ? 0 : 1
 	});
+	page.fields_dict.employee.$input.on('change', function() {
+      refresh_tasks(page);
+  });
 	let employeeGroupField = page.add_field({
 		label: __("Employee Group"),
 		fieldname: "employee_group",
 		fieldtype: "Link",
 		options: "Employee Group",
 		change() {
-			refresh_tasks(page);
+			if (page.fields_dict.employee_group.get_value()) {
+          refresh_tasks(page);
+      }
 		}
 	});
+	page.fields_dict.employee_group.$input.on('change', function() {
+      refresh_tasks(page);
+  });
 	let categoryField = page.add_field({
 		label: __("Department"),
 		fieldname: "department",
 		fieldtype: "Link",
 		options: "Department",
 		change() {
-			refresh_tasks(page);
+			if (page.fields_dict.department.get_value()) {
+          refresh_tasks(page);
+      }
 		}
 	});
+	page.fields_dict.department.$input.on('change', function() {
+      refresh_tasks(page);
+  });
 	let subcategoryField = page.add_field({
 		label: __("Compliance Sub Category"),
 		fieldname: "compliance_sub_category",
 		fieldtype: "Link",
 		options: "Compliance Sub Category",
 		change() {
-			refresh_tasks(page);
+			if (page.fields_dict.compliance_sub_category.get_value()) {
+          refresh_tasks(page);
+      }
 		}
 	});
+	page.fields_dict.compliance_sub_category.$input.on('change', function() {
+      refresh_tasks(page);
+  });
 	let fromDateField = page.add_field({
 		label: __("From Date"),
 		fieldname: "from_date",
@@ -86,6 +121,9 @@ function make_filters(page) {
 			refresh_tasks(page);
 		}
 	});
+	page.fields_dict.from_date.$input.on('change', function() {
+      refresh_tasks(page);
+  });
 	let toDateField = page.add_field({
 		label: __("To Date"),
 		fieldname: "to_date",
@@ -94,6 +132,9 @@ function make_filters(page) {
 			refresh_tasks(page);
 		}
 	});
+	page.fields_dict.to_date.$input.on('change', function() {
+      refresh_tasks(page);
+  });
 	let status = page.add_field({
 		label: __("Status"),
 		fieldname: "status",
@@ -130,7 +171,7 @@ function show(page){
 
 function refresh_tasks(page){
 	// Clear existing tasks from the page
-  page.body.find(".task-entry").remove();
+  page.body.find(".frappe-list").remove();
 
 	const selectedStatus = page.fields_dict.status.get_value();
 	const taskName = page.fields_dict.task.get_value();
@@ -244,7 +285,10 @@ function refresh_tasks(page){
 						set_status_colors();
 						hide_add_assignee_button(page.fields_dict.status.get_value());
 						assignee_and_completed_by_section(page.fields_dict.status.get_value());
-				}
+				} else {
+            // If no tasks are found, append a message to the page body
+            $('<div class="frappe-list"></div>').appendTo(page.body).append('<div class="no-result text-muted flex justify-center align-center" style="text-align: center;"><p>No Task found with matching filters.</p></div>');
+        }
 			},
 			freeze: true,
 			freeze_message: 'Loading Task List'
@@ -614,20 +658,20 @@ function update_status(taskName, projectId, taskId, isPayable) {
 		primary_action_label: 'Update',
 		primary_action(values) {
 			if (values.reimbursement_amount > 0) {
-            update_reimbursement_amount(values, projectId, d, taskId);
-        } 
+            update_reimbursement_amount(values, d, taskId);
+        }
 		},
 	});
 	d.set_value('completed_by', frappe.session.user);
 d.show();
 }
 
-function update_reimbursement_amount(values, projectId, d, taskId) {
+function update_reimbursement_amount(values, d, taskId) {
 	frappe.call({
-		method: 'one_compliance.one_compliance.page.task_management_tool.task_management_tool.update_reimbursement_amount',
+		method: 'one_compliance.one_compliance.page.task_management_tool.task_management_tool.add_payable_amount',
 		args: {
-			'project_id': projectId,
-			'reimbursement_amount': values.reimbursement_amount
+			'task_id': taskId,
+			'payable_amount': values.reimbursement_amount
 		},
 		callback: function(r){
 			if (r.message){

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
@@ -133,10 +133,23 @@ def create_timesheet(project, task, employee, activity, from_time, to_time):
         frappe.db.commit()
 
 @frappe.whitelist()
-def update_reimbursement_amount(project_id, reimbursement_amount):
+def add_payable_amount(task_id, payable_amount):
+    print(payable_amount)
+    task = frappe.get_doc("Task", task_id)
+    task.custom_payable_amount = payable_amount
+    task.save()
+    update_reimbursement_amount(task.project)
+    return task
+
+@frappe.whitelist()
+def update_reimbursement_amount(project_id):
+    total_payable_amount = frappe.db.get_value("Task", {"project": project_id, "custom_payable_amount": (">", 0)},"sum(custom_payable_amount)")
+    print(total_payable_amount)
+    # Update reimbursement amount in the project
     project = frappe.get_doc("Project", project_id)
-    project.custom_reimbursement_amount = reimbursement_amount
+    project.custom_reimbursement_amount = total_payable_amount
     project.save()
+    frappe.db.commit()
     return project
 
 @frappe.whitelist()


### PR DESCRIPTION
## Feature description
Added compliance agreement field in the update compliance date button.
Fix code error in the task management tool. 
Show "task is not found for matching filter" if it is empty.

## Solution description
Added compliance agreement field in the update compliance date button to update the compliance_date of a particular compliance agreement.
Fix code error in the task management tool. Show "task is not found for matching filter" if it is empty.

## Output screenshots 
![image](https://github.com/efeone/one_compliance/assets/84098652/40467df2-0920-4c05-8e58-1238bc59f2e8)
![image](https://github.com/efeone/one_compliance/assets/84098652/168e5aa7-8643-40af-bd58-ba27c855eae0)
![image](https://github.com/efeone/one_compliance/assets/84098652/6b37367b-a65e-4ffc-9524-f9207d7733ee)

## Areas affected and ensured
compliance_agreement.js, compliance_agreement.py and task_management_tool page are affected and ensured.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome