### PR TITLE
feat:Create project and assign manually from sales order

### DIFF
--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -14,11 +14,14 @@ def get_compliance_subcategory(item_code):
     }
 
 @frappe.whitelist()
-def create_project_from_sales_order(sales_order, start_date, item_code, priority, expected_end_date=None, remark=None):
+def create_project_from_sales_order(sales_order, start_date, item_code, priority, assign_to=None, expected_end_date=None, remark=None):
+    if(assign_to):
+        employees = json.loads(assign_to)
     self = frappe.get_doc('Sales Order', sales_order)
     compliance_sub_category = frappe.get_doc('Compliance Sub Category',{'item_code':item_code})
     project_template  = compliance_sub_category.project_template
     project_template_doc = frappe.get_doc('Project Template', project_template)
+    head_of_department = frappe.db.get_value('Employee', {'employee':compliance_sub_category.head_of_department}, 'user_id')
     if project_template:
         repeat_on = compliance_sub_category.repeat_on
         project_based_on_prior_phase = compliance_sub_category.project_based_on_prior_phase
@@ -39,63 +42,100 @@ def create_project_from_sales_order(sales_order, start_date, item_code, priority
             naming = str(naming_year) + ' ' + naming_quarter
         else:
             naming = str(naming_year) + ' ' + naming_month
-        project = frappe.new_doc('Project')
-        project.company = self.company
-        project.cost_center = frappe.get_cached_value("Company", self.company, "cost_center")
-        project.project_name = self.customer_name + '-' + compliance_sub_category.name + '-' + self.name + '-' + str(naming)
-        project.customer = self.customer
-        project.compliance_sub_category = compliance_sub_category.name
-        project.compliance_category = compliance_sub_category.compliance_category
-        project.expected_start_date = start_date
-        if expected_end_date:
-            days_diff = date_diff(getdate(expected_end_date), getdate(start_date))
-            if(days_diff > project_template_doc.custom_project_duration):
-                project.expected_end_date = expected_end_date
-            else:
-                project.expected_end_date = add_days(start_date, project_template_doc.custom_project_duration)
+        if not assign_to and not any(template_task.type and template_task.employee_or_group for template_task in project_template_doc.tasks):
+            frappe.msgprint("Project can't be created since no assignees are specified in tasks")
         else:
-            if project_template_doc.custom_project_duration:
-                project.expected_end_date = add_days(start_date, project_template_doc.custom_project_duration)
-        project.priority = priority
-        project.custom_project_service = compliance_sub_category.name + '-' + str(naming)
-        project.notes = remark
-        project.sales_order = sales_order
-        project.category_type = compliance_sub_category.category_type
-        project.save(ignore_permissions=True)
-        frappe.db.commit()
-        frappe.msgprint('Project Created for {0}.'.format(compliance_sub_category.name), alert = 1)
-        for template_task in project_template_doc.tasks:
-            ''' Method to create task against created project from the Project Template '''
-            template_task_doc = frappe.get_doc('Task', template_task.task)
-            user_name = frappe.get_cached_value("User", frappe.session.user, "full_name")
-            task_doc = frappe.new_doc('Task')
-            task_doc.compliance_sub_category = compliance_sub_category.name
-            task_doc.subject = template_task.subject
-            task_doc.project = project.name
-            task_doc.company = project.company
-            task_doc.project_name = project.project_name
-            task_doc.category_type = project.category_type
-            task_doc.exp_start_date = start_date
-            if template_task_doc.expected_time:
-                task_doc.expected_time = template_task_doc.expected_time
-            if template_task.custom_task_duration:
-                task_doc.duration = template_task.custom_task_duration
-                task_doc.exp_end_date = add_days(start_date, template_task.custom_task_duration)
-            task_doc.save(ignore_permissions=True)
-            if template_task.type and template_task.employee_or_group:
-                frappe.db.set_value('Task', task_doc.name, 'assigned_to', template_task.employee_or_group)
-                if template_task.type == "Employee":
-                    employee = frappe.db.get_value('Employee', template_task.employee_or_group, 'user_id')
-                    if employee:
-                        create_todo('Task', task_doc.name, employee, employee, 'Task {0} Assigned Successfully'.format(task_doc.name))
-                        create_notification_log('{0} Assigned a New Task {1} to You'.format(user_name, task_doc.name),'Mention', employee, 'Task {0} Assigned Successfully'.format(task_doc.name), task_doc.doctype, task_doc.name)
-                if template_task.type == "Employee Group":
-                    employee_group = frappe.get_doc('Employee Group', template_task.employee_or_group)
-                    if employee_group.employee_list:
-                        for employee in employee_group.employee_list:
-                            create_todo('Task', task_doc.name, employee.user_id, employee.user_id, 'Task {0} Assigned Successfully'.format(task_doc.name))
-                            create_notification_log('{0} Assigned a New Task {1} to you'.format(user_name, task_doc.name),'Mention', employee.user_id, 'Task {0} Assigned Successfully'.format(task_doc.name), task_doc.doctype, task_doc.name)
+            project = frappe.new_doc('Project')
+            project.company = self.company
+            project.cost_center = frappe.get_cached_value("Company", self.company, "cost_center")
+            project.project_name = self.customer_name + '-' + compliance_sub_category.name + '-' + self.name + '-' + str(naming)
+            project.customer = self.customer
+            project.compliance_sub_category = compliance_sub_category.name
+            project.compliance_category = compliance_sub_category.compliance_category
+            project.expected_start_date = start_date
+            if expected_end_date:
+                days_diff = date_diff(getdate(expected_end_date), getdate(start_date))
+                if(days_diff > project_template_doc.custom_project_duration):
+                    project.expected_end_date = expected_end_date
+                else:
+                    project.expected_end_date = add_days(start_date, project_template_doc.custom_project_duration)
+            else:
+                if project_template_doc.custom_project_duration:
+                    project.expected_end_date = add_days(start_date, project_template_doc.custom_project_duration)
+            project.priority = priority
+            project.custom_project_service = compliance_sub_category.name + '-' + str(naming)
+            project.notes = remark
+            project.sales_order = sales_order
+            project.category_type = compliance_sub_category.category_type
+            project.save(ignore_permissions=True)
+            if project.compliance_sub_category:
+                if compliance_sub_category and compliance_sub_category.head_of_department:
+                    todo = frappe.new_doc('ToDo')
+                    todo.status = 'Open'
+                    todo.allocated_to = head_of_department
+                    todo.description = "project  Assign to " + head_of_department
+                    todo.reference_type = 'Project'
+                    todo.reference_name = project.name
+                    todo.assigned_by = frappe.session.user
+                    todo.save(ignore_permissions=True)
+                    if todo:
+                        frappe.msgprint(("Project is assigned to {0}".format(head_of_department)),alert = 1)
+            if assign_to:
+                user_name = frappe.get_cached_value("User", frappe.session.user, "full_name")
+                for employee in employees:
+                    user = frappe.db.get_value('Employee', employee, 'user_id')
+                    if user and user != head_of_department:
+                        create_todo('Project', project.name, user, user, 'Project {0} Assigned Successfully'.format(project.name))
+                        create_notification_log('{0} Assigned a New Project {1} to You'.format(user_name, project.name),'Mention', user, 'Project {0} Assigned Successfully'.format(project.name), project.doctype, project.name)
+            frappe.msgprint('Project Created for {0}.'.format(compliance_sub_category.name), alert = 1)
+            for template_task in project_template_doc.tasks:
+                ''' Method to create task against created project from the Project Template '''
+                template_task_doc = frappe.get_doc('Task', template_task.task)
+                user_name = frappe.get_cached_value("User", frappe.session.user, "full_name")
+                task_doc = frappe.new_doc('Task')
+                task_doc.compliance_sub_category = compliance_sub_category.name
+                task_doc.subject = template_task.subject
+                task_doc.project = project.name
+                task_doc.company = project.company
+                task_doc.project_name = project.project_name
+                task_doc.category_type = project.category_type
+                task_doc.exp_start_date = start_date
+                if template_task_doc.expected_time:
+                    task_doc.expected_time = template_task_doc.expected_time
+                if template_task.custom_task_duration:
+                    task_doc.duration = template_task.custom_task_duration
+                    task_doc.exp_end_date = add_days(start_date, template_task.custom_task_duration)
+                task_doc.save(ignore_permissions=True)
+                if project.compliance_sub_category:
+                    if compliance_sub_category and compliance_sub_category.head_of_department:
+                        todo = frappe.new_doc('ToDo')
+                        todo.status = 'Open'
+                        todo.allocated_to = head_of_department
+                        todo.description = "Task Assign to " + head_of_department
+                        todo.reference_type = 'Task'
+                        todo.reference_name = task_doc.name
+                        todo.assigned_by = frappe.session.user
+                        todo.save(ignore_permissions=True)
+                if assign_to:
+                    for employee in employees:
+                        user = frappe.db.get_value('Employee', employee, 'user_id')
+                        if user and user != head_of_department:
+                            create_todo('Task', task_doc.name, user, user, 'Task {0} Assigned Successfully'.format(task_doc.name))
+                            create_notification_log('{0} Assigned a New Task {1} to You'.format(user_name, task_doc.name),'Mention', user, 'Task {0} Assigned Successfully'.format(task_doc.name), task_doc.doctype, task_doc.name)
+                elif not assign_to and template_task.type and template_task.employee_or_group:
+                    frappe.db.set_value('Task', task_doc.name, 'assigned_to', template_task.employee_or_group)
+                    if template_task.type == "Employee":
+                        employee = frappe.db.get_value('Employee', template_task.employee_or_group, 'user_id')
+                        if employee and employee != head_of_department:
+                            create_todo('Task', task_doc.name, employee, employee, 'Task {0} Assigned Successfully'.format(task_doc.name))
+                            create_notification_log('{0} Assigned a New Task {1} to You'.format(user_name, task_doc.name),'Mention', employee, 'Task {0} Assigned Successfully'.format(task_doc.name), task_doc.doctype, task_doc.name)
+                    if template_task.type == "Employee Group":
+                        employee_group = frappe.get_doc('Employee Group', template_task.employee_or_group)
+                        if employee_group.employee_list:
+                            for employee in employee_group.employee_list:
+                                create_todo('Task', task_doc.name, employee.user_id, employee.user_id, 'Task {0} Assigned Successfully'.format(task_doc.name))
+                                create_notification_log('{0} Assigned a New Task {1} to you'.format(user_name, task_doc.name),'Mention', employee.user_id, 'Task {0} Assigned Successfully'.format(task_doc.name), task_doc.doctype, task_doc.name)
 
-        frappe.db.commit()
+            frappe.db.commit()
     else:
         frappe.throw( title = _('ALERT !!'), msg = _('Project Template does not exist for {0}'.format(compliance_sub_category)))

--- a/one_compliance/public/js/sales_order.js
+++ b/one_compliance/public/js/sales_order.js
@@ -79,6 +79,14 @@ let create_project_from_sales_order = function (frm) {
         read_only: true
       },
       {
+          label: __("Assign To"),
+          fieldname: "assign_to",
+          fieldtype: 'MultiSelectPills',
+          get_data: function (txt) {
+            return frappe.db.get_link_options("Employee", txt);
+          },
+      },
+      {
         fieldtype: "Section Break",
         fieldname: "col_break_1",
       },
@@ -100,7 +108,8 @@ let create_project_from_sales_order = function (frm) {
               expected_end_date: values.expected_end_date,
               item_code: values.item,
               priority: values.priority,
-              remark: values.remark
+              remark: values.remark,
+              assign_to: values.assign_to
             },
             callback: function (r) {
               if (r.message) {


### PR DESCRIPTION
## Feature description
Create project and assign manually from sales order. 
Added assign_to field in the dialog box of create project. Assign project and task to head_of_department and assignees

## Areas affected and ensured
sales.order.js and sales_order.py

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome