### PR TITLE
feat:Create sales invoice from Lead

### DIFF
--- a/one_compliance/one_compliance/doc_events/lead.py
+++ b/one_compliance/one_compliance/doc_events/lead.py
@@ -1,0 +1,24 @@
+import frappe
+import json
+
+@frappe.whitelist()
+def create_sales_invoice(doc_name, services):
+    service = json.loads(services)
+    lead = frappe.get_doc('Lead',doc_name)
+    customer_type = frappe.db.get_single_value("Compliance Settings", 'customer_type')
+    customer = frappe.new_doc('Customer')
+    customer.customer_name = lead.lead_name
+    customer.compliance_customer_type = customer_type
+    customer.lead_name = lead.name
+    customer.insert(ignore_permissions = True)
+    sales_invoice = frappe.new_doc('Sales Invoice')
+    sales_invoice.customer = customer.name
+    for item in service:
+        sales_invoice.append('items', {
+            'item_code': item,
+            'qty':1,
+        })
+
+    sales_invoice.insert(ignore_permissions = True)
+    frappe.msgprint(f"Sales Invoice {sales_invoice.name} created successfully.")
+    return sales_invoice.name

--- a/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.json
+++ b/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.json
@@ -12,6 +12,8 @@
   "section_break_saeum",
   "role_of_project_creator",
   "compliance_service_item_group",
+  "column_break_gnzz",
+  "customer_type",
   "tab_break_us4n3",
   "task_before_due_date_notification",
   "task_overdue_notification_for_employee",
@@ -108,12 +110,22 @@
   {
    "fieldname": "section_break_saeum",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_gnzz",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "customer_type",
+   "fieldtype": "Link",
+   "label": "Customer Type",
+   "options": "Customer Type"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-02-26 15:35:36.230789",
+ "modified": "2024-03-05 12:14:05.271619",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Compliance Settings",

--- a/one_compliance/public/js/lead.js
+++ b/one_compliance/public/js/lead.js
@@ -5,6 +5,42 @@ frappe.ui.form.on('Lead',{
                 frm.remove_custom_button('Customer','Create')
                 frm.remove_custom_button('Quotation','Create')
                 })
+            frm.add_custom_button(__('Sales Invoice'), function () {
+                create_sales_invoice(frm);
+            },__("Create"));
           }
       }
   });
+
+let create_sales_invoice = function (frm) {
+  let d = new frappe.ui.Dialog({
+    title: 'Enter details',
+    fields: [
+      {
+          label: __("Services"),
+          fieldname: "services",
+          fieldtype: 'MultiSelectPills',
+          get_data: function (txt) {
+            return frappe.db.get_link_options("Item", txt);
+          },
+      },
+    ],
+    primary_action_label: 'Create',
+    primary_action(values) {
+      console.log(frm.doc.name);
+      frappe.call({
+        method: 'one_compliance.one_compliance.doc_events.lead.create_sales_invoice',
+        args: {
+            doc_name: frm.doc.name,
+            services:values.services,
+        },
+        callback: function (r) {
+          if (r.message) {
+            d.hide();
+          }
+        }
+      });
+    }
+  });
+  d.show();
+}


### PR DESCRIPTION
## Feature description
Create sales invoice from Lead by creating customer also. Added a field customer_type in compliance settings and fetch the value to the customer to create customer from lead.

## Areas affected and ensured
lead.js, lead.py and compliance_settings.json

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome