### PR TITLE
feat:Validation for documents

### DIFF
--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -121,6 +121,7 @@ doc_events = {
     'Task':{
         'on_update':['one_compliance.one_compliance.doc_events.task.task_on_update',
                     'one_compliance.one_compliance.doc_events.task.make_sales_invoice',
+                    'one_compliance.one_compliance.doc_events.task.subtask_on_update',
                     ],
         'validate':['one_compliance.one_compliance.doc_events.task.append_users_to_project',
                     'one_compliance.one_compliance.doc_events.task.set_task_status_to_hold',

--- a/one_compliance/one_compliance/doc_events/task.py
+++ b/one_compliance/one_compliance/doc_events/task.py
@@ -216,3 +216,11 @@ def get_rate_from_compliance_agreement(compliance_agreement, compliance_sub_cate
 		)
 	if rate_result:
 		return rate_result[0].rate
+
+# Check for uncompleted documents on updation of task to completed
+@frappe.whitelist()
+def subtask_on_update(doc, event):
+    if doc.status == "Completed":
+        items = frappe.get_all("Task Document Item", filters={"parent": doc.name}, fields=["is_completed"])
+        if any(item.get("is_completed") == 0 for item in items):
+            frappe.throw(_("Please complete all documents before marking the task as complete"))


### PR DESCRIPTION
## Feature description
Validation for checking whether all documents are completed when task status is updating to completed.




## Output screenshots (optional)
![image](https://github.com/efeone/one_compliance/assets/138565705/c29dddbe-c2a6-4434-8add-a8fa2df29bd4)


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
