### PR TITLE
feat: Added a check field in Compliance settings to delete project along with compliance agreement

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
@@ -39,7 +39,16 @@ class ComplianceAgreement(Document):
 		self.change_agreement_status()
 
 	def on_trash(self):
-		delete_project_and_task(self.name)
+		delete_project_along_with_compliance_agreement = frappe.db.get_single_value('Compliance Settings', 'delete_project_along_with_compliance_agreement')
+		if delete_project_along_with_compliance_agreement:
+			delete_project_and_task(self.name)
+		else:
+			if frappe.db.exists('Project',{'compliance_agreement': self.name}):
+				project_list = frappe.db.get_all('Project', filters={'compliance_agreement': self.name})
+				for project in project_list:
+					project_doc = frappe.get_doc('Project',project.name)
+					project_doc.set('compliance_agreement', None)
+					project_doc.save()
 
 
 	def validate_agreement_dates(self):

--- a/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.json
+++ b/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.json
@@ -12,6 +12,7 @@
   "add_compliance_category_in_project_name",
   "column_break_begm",
   "create_project_from_sales_order_automatically",
+  "delete_project_along_with_compliance_agreement",
   "section_break_saeum",
   "role_of_project_creator",
   "compliance_service_item_group",
@@ -178,12 +179,18 @@
    "fieldtype": "Link",
    "label": "DIN KYC Sub Category",
    "options": "Compliance Sub Category"
+  },
+  {
+   "default": "0",
+   "fieldname": "delete_project_along_with_compliance_agreement",
+   "fieldtype": "Check",
+   "label": "Delete Project Along with Compliance Agreement"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-04-09 10:45:33.146827",
+ "modified": "2024-04-16 11:17:12.059667",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Compliance Settings",


### PR DESCRIPTION
## Feature description
Added a check field in Compliance settings to delete project along with compliance agreement

## Solution description
Added a check field in Compliance settings to delete project along with compliance agreement. If the check field is checked, then on deleting the compliance agreement project and task should also deleted. Else the compliance agreement field in the project set to None value, and compliance agreement get deleted.

## Areas affected and ensured
compliance_settings.json and compliance_agreement.py

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome