### PR TITLE
feat:Viewing the Customer Document Tool via a button in the Customer Document.

### DIFF
--- a/one_compliance/one_compliance/doctype/customer_document/customer_document.js
+++ b/one_compliance/one_compliance/doctype/customer_document/customer_document.js
@@ -2,7 +2,12 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Customer Document', {
-	// refresh: function(frm) {
-
-	// }
+	refresh: function(frm) {
+    frm.add_custom_button('Customer Tool Page', function() {
+        var customer = frm.doc.customer;
+        localStorage.setItem('selected_customer', customer);
+        // Replace 'tool-page-url' with the actual URL of the Customer document tool page
+        window.location.href = '/app/customer-document-tool';
+    });
+	}
 });

--- a/one_compliance/one_compliance/page/customer_document_tool/customer_document_tool.css
+++ b/one_compliance/one_compliance/page/customer_document_tool/customer_document_tool.css
@@ -1,17 +1,14 @@
+/* Set a minimum height for elements with the class frappe-card */
 .frappe-card {
   min-height: 300px;
 }
 
-.caret-down::before {
-  -ms-transform: rotate(90deg); /* IE 9 */
-  -webkit-transform: rotate(90deg); /* Safari */'
-  transform: rotate(90deg);
-}
-
+/* Hide elements with the class 'nested' by default */
 .nested {
   display: none;
 }
 
+/* Show elements with the class 'nested' when the 'active' class is applied */
 .active {
   display: block;
 }

--- a/one_compliance/one_compliance/page/customer_document_tool/customer_document_tool.html
+++ b/one_compliance/one_compliance/page/customer_document_tool/customer_document_tool.html
@@ -1,4 +1,5 @@
 <div class="tree with-skeleton">
+  <!-- List compliance categories -->
   {% for category in categories %}
   <ul class="tree-children">
     <li class="tree-node">
@@ -11,6 +12,7 @@
         <a class="tree-label">{{ category.category }}</a>
       </span>
       <ul class="tree-children nested">
+        <!-- List the compliance sub categories inside the categories -->
         {% for sub_category in category.sub_categories %}
         <li class="tree-node">
           <span class="tree-link">
@@ -21,10 +23,12 @@
             </span>
             <a class="tree-label subCategory">{{ sub_category.sub_category }}</a>
           </span>
+          <!-- Button for adding new documents -->
           <span class="tree-node-toolbar btn-group" style="display:none;">
             <button class="btn btn-default btn-xs tree-toolbar-button hidden-xs addDocument" sub-category="{{ sub_category.sub_category }}">Add</button>
           </span>
           <ul class="tree-children nested">
+            <!-- List all the documents under the compliance sub category -->
             {% for documents in sub_category.documents %}
             {% if documents.document_attachment %}
             <li class="tree-node">
@@ -36,6 +40,7 @@
                 </span>
                 <a class="tree-label">{{ documents.document_attachment }}</a>
               </span>
+              <!-- Button for download the document -->
               <span class="tree-node-toolbar btn-group" style="display:none;">
                 <button class="btn btn-default btn-xs tree-toolbar-button hidden-xs downloadDocument" doc-id="{{ documents.document_attachment }}">Download</button>
               </span>
@@ -50,6 +55,8 @@
   </ul>
   {% endfor %}
 </div>
+
+<!-- Script for dropdown action -->
 <script>
 var toggler = document.getElementsByClassName("tree-link");
 var i;

--- a/one_compliance/one_compliance/page/customer_document_tool/customer_document_tool.js
+++ b/one_compliance/one_compliance/page/customer_document_tool/customer_document_tool.js
@@ -9,16 +9,28 @@ frappe.pages['customer-document-tool'].on_page_load = function(wrapper) {
 
 	make_filters(page);
 
-	$('<div class="tree"></div>').appendTo(page.body).append('<div class="no-result text-muted flex justify-center align-center" style="text-align: center; min-height: 250px;"><p>Select Customer to view the Documents.</p></div>');
+	//Retrieve the selected customer from local storage that set from customer document
+	var customer = localStorage.getItem('selected_customer');
+	if (customer) {
+		//if there is customer then refresh the pages
+		refresh_page(page);
+	} else {
+		//if there is no customer selected, display a message to select a customer initially
+		$('<div class="tree"></div>').appendTo(page.body).append('<div class="no-result text-muted flex justify-center align-center" style="text-align: center; min-height: 250px;"><p>Select Customer to view the Documents.</p></div>');
+	}
 
 }
 
 function make_filters(page) {
+	var customer = localStorage.getItem('selected_customer');
+
+	// Add the customer field with the default value if it exists in local storage
 	let customerField = page.add_field({
 		label: __("Customer"),
 		fieldname: "customer",
 		fieldtype: "Link",
 		options:"Customer",
+		default: customer,
 		change() {
 			if (page.fields_dict.customer.get_value()) {
           refresh_page(page);
@@ -27,13 +39,17 @@ function make_filters(page) {
 	});
 	page.fields_dict.customer.$input.on('change', function() {
 		if (!page.fields_dict.customer.get_value()) {
+				// Remove the existing tree element to prevent repetition
 				page.body.find(".tree").remove();
+				//if there is no customer selected, display a message to select a customer
 				$('<div class="tree"></div>').appendTo(page.body).append('<div class="no-result text-muted flex justify-center align-center" style="text-align: center; min-height: 250px;"><p>Select Customer to view the Documents.</p></div>');
 		}
   });
 }
 
 function refresh_page(page){
+	// Remove the selected value from local storage once retrieved
+	localStorage.removeItem('selected_customer');
 	page.body.find(".tree").remove();
 
 	const customerName = page.fields_dict.customer.get_value();
@@ -47,32 +63,47 @@ function refresh_page(page){
 				if(r.message && r.message.length>0){
 					var categories = r.message;
 
+					// Render the values to html page
 					$(frappe.render_template("customer_document_tool",{categories})).appendTo(page.body);
 
+					// Display button once click on the sub category and documents
 					page.body.find(".tree-label").on("click", function() {
 							$(".tree-node-toolbar").hide();
 					    var toolbar = $(this).closest('.tree-link').next('.tree-node-toolbar');
 					    toolbar.show();
 					});
 
+					// Button action to add new document for existing customer
 					page.body.find(".addDocument").on("click", function () {
 						var sub_category = $(this).attr("sub-category");
 						add_customer_document(customerName, sub_category)
 					});
 
+					// Button action to download the document
 					page.body.find(".downloadDocument").on("click", function () {
 						var document = $(this).attr("doc-id");
 						window.open(document)
 					});
 				} else {
-            // If no projects are found, append a message to the page body
-						$('<div class="tree"></div>').appendTo(page.body).append('<div class="no-result text-muted flex justify-center align-center" style="text-align: center; min-height: 250px;"><p>No Documents found against this Customer.</p></div>');
-        }
+					// If no projects are found, append a message to the page body
+					$('<div class="tree"></div>').appendTo(page.body).append('<div class="no-result text-muted flex justify-center align-center" style="text-align: center; min-height: 250px;"><p>No Documents found against this Customer. Create document from here.<br><button class="btn btn-default btn-xs tree-toolbar-button hidden-xs addDocument" customer="page.fields_dict.customer.get_value()">Create a new Task Document</button></p></div>');
+
+					// Button action to create new customer document for a customer who hasn't document.
+					page.body.find(".addDocument").on("click", function () {
+						customer = page.fields_dict.customer.get_value()
+						frappe.model.with_doctype('Customer Document', function() {
+				        var newDoc = frappe.model.get_new_doc('Customer Document');
+				        newDoc.customer = customer;
+				        frappe.set_route('Form', 'Customer Document', newDoc.name);
+				    });
+					});
+				}
 			}
 	});
 
 }
 
+// Function to add customer document.
 function add_customer_document(customer, sub_category) {
 	frappe.call({
 		method: 'one_compliance.one_compliance.page.customer_document_tool.customer_document_tool.add_customer_document',
@@ -83,6 +114,7 @@ function add_customer_document(customer, sub_category) {
 		callback: function (r) {
 				if (r) {
 					frappe.set_route("Form", r.message.doctype, r.message.name);
+					window.location.reload();
 				}
 			},
 	});

--- a/one_compliance/one_compliance/page/customer_document_tool/customer_document_tool.py
+++ b/one_compliance/one_compliance/page/customer_document_tool/customer_document_tool.py
@@ -3,6 +3,7 @@ from frappe.model.mapper import get_mapped_doc
 
 @frappe.whitelist()
 def get_compliance_categories(customer = None):
+    # Construct the SQL query to fetch customer document details
     query = """
 	SELECT
         S.compliance_category, S.name, R.document_attachment,D.customer
@@ -14,9 +15,12 @@ def get_compliance_categories(customer = None):
             query += f" WHERE D.customer = '{customer}';"
 
     document_list = frappe.db.sql(query, as_dict=1)
+
+    # Constructs a hierarchical data structure representing compliance categories,
+    # each containing sub-categories, and their associated documents based on the query results.
     hierarchical_data = []
     for item in document_list:
-        # Check if the category already exists
+        # Check if the category already exists in the hierarchical data
         category_exists = False
         for category_item in hierarchical_data:
             if category_item['category'] == item['compliance_category']:
@@ -31,6 +35,7 @@ def get_compliance_categories(customer = None):
                             'customer': item['customer']
                         })
                         break
+                # If sub category doesn't exist, add it
                 if not sub_category_exists:
                     category_item['sub_categories'].append({
                         'sub_category': item['name'],
@@ -61,7 +66,6 @@ def add_customer_document(sub_category, customer):
     # Search for an existing Customer Document for the selected customer
     if customer:
         existing_doc = frappe.get_doc('Customer Document', {'customer': customer}, 'name')
-        print(existing_doc)
         if existing_doc:
             # If an existing Customer Document is found, return it
             return existing_doc


### PR DESCRIPTION
## Feature description
Viewing the Customer Document Tool via a button in the Customer Document. Create new Customer Document from page if no document for a customer.

## Solution description
Viewing the Customer Document Tool via a button in the Customer Document. Create new Customer Document from page if no document for a customer.

## Areas affected and ensured
customer_document.js, customer_document_tool

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome