### PR TITLE
feat: Sales Order Workflow

### DIFF
--- a/one_compliance/fixtures/workflow.json
+++ b/one_compliance/fixtures/workflow.json
@@ -362,5 +362,106 @@
   "workflow_data": null,
   "workflow_name": "Sales Invoice Workflow",
   "workflow_state_field": "workflow_state"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow",
+  "document_type": "Sales Order",
+  "is_active": 1,
+  "modified": "2024-06-13 17:07:00.342584",
+  "name": "Sales Order Workflow",
+  "override_status": 0,
+  "send_email_alert": 0,
+  "states": [
+   {
+    "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Sales Order Workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Pending",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
+    "doc_status": "1",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Sales Order Workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "In Progress",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
+    "doc_status": "1",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Sales Order Workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Proforma Invoice",
+    "update_field": "",
+    "update_value": "",
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "Accounts User",
+    "avoid_status_override": 0,
+    "doc_status": "1",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Sales Order Workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Closed",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   }
+  ],
+  "transitions": [
+   {
+    "action": "Proceed",
+    "allow_self_approval": 1,
+    "allowed": "Accounts User",
+    "condition": null,
+    "next_state": "In Progress",
+    "parent": "Sales Order Workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Pending",
+    "workflow_builder_id": null
+   },
+   {
+    "action": "Close",
+    "allow_self_approval": 1,
+    "allowed": "Accounts User",
+    "condition": null,
+    "next_state": "Closed",
+    "parent": "Sales Order Workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Proforma Invoice",
+    "workflow_builder_id": null
+   }
+  ],
+  "workflow_data": null,
+  "workflow_name": "Sales Order Workflow",
+  "workflow_state_field": "workflow_state"
  }
 ]

--- a/one_compliance/fixtures/workflow_action_master.json
+++ b/one_compliance/fixtures/workflow_action_master.json
@@ -89,5 +89,19 @@
   "modified": "2024-02-16 15:59:04.169976",
   "name": "Cancel",
   "workflow_action_name": "Cancel"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow Action Master",
+  "modified": "2024-06-13 17:01:15.316090",
+  "name": "Proceed",
+  "workflow_action_name": "Proceed"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow Action Master",
+  "modified": "2024-06-13 17:06:50.749691",
+  "name": "Close",
+  "workflow_action_name": "Close"
  }
 ]

--- a/one_compliance/fixtures/workflow_state.json
+++ b/one_compliance/fixtures/workflow_state.json
@@ -106,5 +106,23 @@
   "name": "Verified",
   "style": "Primary",
   "workflow_state_name": "Verified"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2024-06-13 17:10:36.009006",
+  "name": "In Progress",
+  "style": "Primary",
+  "workflow_state_name": "In Progress"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2024-06-13 17:10:24.835132",
+  "name": "Closed",
+  "style": "Success",
+  "workflow_state_name": "Closed"
  }
 ]

--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -264,15 +264,15 @@ fixtures = [
     },
     {
         'dt': 'Workflow State',
-        'filters': [['name', 'in', ['Draft','Approved','Rejected','Pending','Sent to Customer','Customer Approval Waiting','Customer Approved','Customer Rejected','Cancelled','Verified','Tax Invoice','Proforma Invoice']]]
+        'filters': [['name', 'in', ['Draft','Approved','Rejected','Pending','Sent to Customer','Customer Approval Waiting','Customer Approved','Customer Rejected','Cancelled','Verified','Tax Invoice','Proforma Invoice', 'Closed', 'In Progress']]]
     },
     {
         'dt': 'Workflow',
-        'filters': [['name', 'in', ['Compliance Agreement Workflow','Sales Invoice Workflow']]]
+        'filters': [['name', 'in', ['Compliance Agreement Workflow','Sales Invoice Workflow', 'Sales Order Workflow']]]
     },
     {
         'dt': 'Workflow Action Master',
-        'filters': [['name', 'in', ['Rejected','Approved','Request for Review','Review','Reject','Approve','Sent to Customer','Customer Approval','Customer Reject','Customer Approval waiting','Cancelled','Generate Proforma Invoice','Generate Tax Invoice','Cancel']]]
+        'filters': [['name', 'in', ['Rejected','Approved','Request for Review','Review','Reject','Approve','Sent to Customer','Customer Approval','Customer Reject','Customer Approval waiting','Cancelled','Generate Proforma Invoice','Generate Tax Invoice','Cancel', 'Proceed', 'Close']]]
     },
     {
         'dt' : 'Notification Template'

--- a/one_compliance/one_compliance/doc_events/task.py
+++ b/one_compliance/one_compliance/doc_events/task.py
@@ -129,6 +129,7 @@ def make_sales_invoice(doc, method):
 						sales_order = frappe.db.exists('Sales Order', project.sales_order)
 						if sales_order:
 							frappe.db.set_value("Sales Order", sales_order, "status", "Proforma Invoice")
+							frappe.db.set_value("Sales Order", sales_order, "workflow_state", "Proforma Invoice")
 						else:
 							payment_terms = None
 							rate = None


### PR DESCRIPTION
## Feature description
Need Sales Order to show status as Proforma Invoice

## Analysis and design
Since statuses in Sales Order is managed by the Selling Controller, a workflow is required to override the status.

## Solution description
- Added a workflow for Sales Order with the required statuses and actions

## Output screenshots
![image](https://github.com/efeone/one_compliance/assets/91651425/28965f01-475b-4c03-9f8e-e29591624b22)

## Areas affected and ensured
Sales Order - Workflow

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
