### PR TITLE
Sales Order Issues

### DIFF
--- a/one_compliance/fixtures/property_setter.json
+++ b/one_compliance/fixtures/property_setter.json
@@ -1,0 +1,18 @@
+[
+ {
+  "default_value": null,
+  "doc_type": "Sales Order Item",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "description",
+  "is_system_generated": 0,
+  "modified": "2024-07-02 15:17:20.278459",
+  "module": "One Compliance",
+  "name": "Sales Order Item-description-allow_on_submit",
+  "property": "allow_on_submit",
+  "property_type": null,
+  "row_name": null,
+  "value": "1"
+ }
+]

--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -303,5 +303,9 @@ fixtures = [
     },
     {
         'dt': 'Translation'
+    },
+    {
+        'dt': 'Property Setter',
+        'filters': [['module', '=', 'One Compliance']]
     }
 ]

--- a/one_compliance/one_compliance/doc_events/project.py
+++ b/one_compliance/one_compliance/doc_events/project.py
@@ -65,10 +65,8 @@ def project_after_insert(doc, method):
 	if frappe.db.exists('Compliance Sub Category', doc.compliance_sub_category):
 		sub_category_doc = frappe.get_doc('Compliance Sub Category', doc.compliance_sub_category)
 		if sub_category_doc.is_billable:
-			print("it is billable!")
 			sales_order = frappe.db.exists('Sales Order', doc.sales_order)
 			if sales_order:
-				print("existing SO")
 				frappe.db.set_value("Sales Order", sales_order, "status", "Proforma Invoice")
 			else:
 				payment_terms = None
@@ -76,7 +74,7 @@ def project_after_insert(doc, method):
 				if frappe.db.exists('Compliance Agreement', doc.compliance_agreement):
 					payment_terms = frappe.db.get_value('Compliance Agreement', doc.compliance_agreement,'default_payment_terms_template')
 					rate = get_rate_from_compliance_agreement(doc.compliance_agreement, doc.compliance_sub_category)
-				create_sales_order(doc, rate, sub_category_doc, payment_terms)
+				create_sales_order(doc, rate, sub_category_doc, payment_terms, submit=True)
 
 @frappe.whitelist()
 def set_status_to_overdue():

--- a/one_compliance/one_compliance/doc_events/task.py
+++ b/one_compliance/one_compliance/doc_events/task.py
@@ -162,7 +162,7 @@ def create_sales_invoice(project, payment_terms, rate, sub_category_doc):
 	sales_invoice.save(ignore_permissions=True)
 
 @frappe.whitelist()
-def create_sales_order(project, rate, sub_category_doc, payment_terms=None):
+def create_sales_order(project, rate, sub_category_doc, payment_terms=None, submit=False):
 	"""method creates a new sales order
 
 	Args:
@@ -170,6 +170,7 @@ def create_sales_order(project, rate, sub_category_doc, payment_terms=None):
 		payment_terms (str): Name of the Payment Terms Template
 		rate (float): Rate of the Item
 		sub_category_doc (ComplianceSubCategory): Document Object of Compliance Sub Category
+		submit (bool): True or False, to submit the sales order or not
 	"""
 	new_sales_order = frappe.new_doc("Sales Order")
 	new_sales_order.customer = project.customer
@@ -189,6 +190,8 @@ def create_sales_order(project, rate, sub_category_doc, payment_terms=None):
 	new_sales_order.insert(ignore_permissions=True)
 	project.sales_order = new_sales_order.name
 	project.save()
+	if submit:
+		new_sales_order.submit()
 	frappe.msgprint("Sales Order {0} Created against {1}".format(new_sales_order.name, project.name), alert=True)
 
 @frappe.whitelist()


### PR DESCRIPTION
## Issue description
Sales Order created from Project was not getting submitted

## Solution description
Auto submit sales orders created from project

## Areas affected and ensured
- Project creation

## Is there any existing behavior change of other features due to this code change?
Yes, Sales Orders created against a new project will now be submitted

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
