### PR TITLE
fix:Validate if Project Template  Doctype Exists for given Compliance Sub Category .

### DIFF
--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -119,7 +119,9 @@ doc_events = {
 		"after_insert": ["one_compliance.one_compliance.doc_events.project_template.update_project_template",
                         ],
         "on_trash": ["one_compliance.one_compliance.doc_events.project_template.on_trash",
-                    ]
+                    ],
+          "validate": ["one_compliance.one_compliance.doc_events.project_template.validate",
+                      ]
 	},
     'Task':{
         'on_update':['one_compliance.one_compliance.doc_events.task.task_on_update',


### PR DESCRIPTION

## Issue description
There is No Validation For checks if Project Template  Doctype exists for given Compliance Sub Category.

## Analysis and design (optional)
Need To Validate For checks if Project Template Doctype  exists for given Compliance Sub Category.

## Solution description
  Validate throws error if a project template with the given compliance sub category is found
 
## Output screenshots (optional)
![image](https://github.com/efeone/one_compliance/assets/170389963/ab71193b-0138-4a3e-926a-14bfeee9ff20)


## Areas affected and ensured 
Validation for the Project Template Doctype.

## Is there any existing behavior change of other features due to this code change?
Project Template Doctype

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
