### PR TITLE
fix:  Fix the Creating Multiple Sales Order Creation in the Event doctype.

### DIFF
--- a/one_compliance/public/js/event.js
+++ b/one_compliance/public/js/event.js
@@ -13,7 +13,7 @@ frappe.ui.form.on('Event',{
             create_sales_order(frm)
           }
           else{
-            frappe.msgprint('Not Billable');
+            frappe.msgprint('Please Mark this Event as Billable');
           }
         },
       );
@@ -32,7 +32,7 @@ frappe.ui.form.on('Event',{
       frm.remove_custom_button("Add Employees", "Add Participants");
     },
     setup: function(frm) {
-      //filter 
+      //filter
       frm.set_query('custom_service', () => {
               return {
                   filters: {


### PR DESCRIPTION
##  Issue description
There is no validation  and  fix the creating the Multiple Sales Order Creation In the Event Doctype.

## Analysis and design (optional)
 validate and the fix the creating the Multiple Sales Order Creation In the Event Doctype.
## Solution description
Validated and the fix the creating the Multiple Sales Order Creation in the Event Doctype.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/2b8fc229-41e7-4e01-927d-56538e64efda)
![image](https://github.com/user-attachments/assets/a3e01c1d-7df8-4223-a68f-b811a74d2f64)
![image](https://github.com/user-attachments/assets/278f646e-f1c3-4f81-b174-275a1c732f1e)

## Areas affected and ensured
Validated and Fix the creating the Multiple Sales Order Creation in the Event Doctype.

## Is there any existing behavior change of other features due to this code change?
sales order doctype

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
