### PR TITLE
fix:Internal projects are made not billable and viceversa

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.js
+++ b/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.js
@@ -53,6 +53,22 @@ frappe.ui.form.on('Compliance Sub Category', {
         }
     }
 	},
+	internal: function(frm) {
+			if (frm.doc.internal) {
+					frm.set_value('is_billable', 0);
+					frm.set_df_property('is_billable', 'read_only', 1);
+			} else {
+					frm.set_df_property('is_billable', 'read_only', 0);
+			}
+	},
+	is_billable: function(frm) {
+			if (frm.doc.is_billable) {
+					frm.set_value('internal', 0);
+					frm.set_df_property('internal', 'read_only', 1);
+			} else {
+					frm.set_df_property('internal', 'read_only', 0);
+			}
+	},
 	validate: function(frm) {
 		if (frm.doc.day) {
 			set_validation_for_day(frm)


### PR DESCRIPTION
## Feature description
Internal projects are made not billable and Is billable projects cannot be internal.

## Solution description
If internal is checked,then Is billable checkbox  is unchecked and made read only.Similarly if Is billable is checked  then internal checkbox cannot be checked.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/844c88ed-0930-42ec-8892-7fe85e021a3c)


## Is there any existing behavior change of other features due to this code change?
   No.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  