### PR TITLE
fix: button to unlink and delete a sales order

### DIFF
--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -302,15 +302,16 @@ def delete_linked_records(sales_order):
 	if frappe.db.exists("Project", project):
 		linked_tasks = frappe.get_all("Task", filters={"project": project})
 		for task in linked_tasks:
-			frappe.delete_doc("Task", task["name"])
+			frappe.delete_doc("Task", task["name"], ignore_permissions=True)
 
 		project_doc = frappe.get_doc("Project", project)
 		project_doc.sales_order = ""
-		project_doc.save()
-		frappe.delete_doc("Project", project)
+		project_doc.save(ignore_permissions=True)
+		frappe.delete_doc("Project", project, ignore_permissions=True)
 
 	doc = frappe.get_doc("Sales Order", sales_order)
+	doc.flags.ignore_permissions = True
 	doc.cancel()
-	frappe.delete_doc("Sales Order", sales_order)
+	frappe.delete_doc("Sales Order", sales_order, ignore_permissions=True)
 
 	return "success"

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -295,16 +295,7 @@ def delete_linked_records(sales_order):
 		"Sales Invoice Item", {"sales_order": sales_order}, "parent"
 	)
 	if frappe.db.exists("Sales Invoice", sales_invoice):
-		si_doc = frappe.get_doc("Sales Invoice", sales_invoice)
-		if frappe.db.exists("Payment Entry Reference", {"reference_doctype":"Sales Invoice", "reference_name":sales_invoice}):
-			payments = frappe.db.get_all("Payment Entry Reference", {"reference_doctype":"Sales Invoice", "reference_name":sales_invoice}, pluck="parent")
-			for payment in payments:
-				payment_doc = frappe.get_doc("Payment Entry", payment)
-				payment_doc.cancel()
-				frappe.delete_doc("Payment Entry", payment)
-
-		si_doc.cancel()
-		frappe.delete_doc("Sales Invoice", sales_invoice)
+		frappe.throw("Cannot proceed with this operation as it is invoiced")
 
 	project = frappe.db.get_value("Sales Order", sales_order, "project")
 

--- a/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.json
+++ b/one_compliance/one_compliance/doctype/compliance_settings/compliance_settings.json
@@ -15,6 +15,7 @@
   "delete_project_along_with_compliance_agreement",
   "section_break_saeum",
   "role_of_project_creator",
+  "role_allowed_to_unlink_and_delete_sales_orders",
   "compliance_service_item_group",
   "default_invoice_due_day",
   "column_break_gnzz",
@@ -250,12 +251,18 @@
    "fieldtype": "Link",
    "label": "Default Tds Account",
    "options": "Account"
+  },
+  {
+   "fieldname": "role_allowed_to_unlink_and_delete_sales_orders",
+   "fieldtype": "Link",
+   "label": "Role Allowed to Unlink and Delete Sales Orders",
+   "options": "Role"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-07-26 15:51:25.595909",
+ "modified": "2024-10-16 12:17:17.395229",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Compliance Settings",

--- a/one_compliance/public/js/sales_order.js
+++ b/one_compliance/public/js/sales_order.js
@@ -27,6 +27,8 @@ frappe.ui.form.on('Sales Order', {
         frm.remove_custom_button('Purchase Order', 'Create');
         frm.remove_custom_button('Project', 'Create');
         }, 500);
+
+        handle_unlinking(frm);
     }
 });
 
@@ -197,3 +199,36 @@ frappe.ui.form.on('Reimbursement Details', {
     });
   }
 });
+
+function handle_unlinking(frm) {
+  if (!frm.is_new()) {
+    frm.add_custom_button("Unlink and Delete", () => {
+      frappe.confirm(
+        __(
+          `Are you sure you want to unlink and delete all linked records of <b>${frm.doc.name}</b>?`
+        ),
+        function () {
+          frappe.call({
+            method:
+              "one_compliance.one_compliance.doc_events.sales_order.delete_linked_records",
+            args: {
+              sales_order: frm.doc.name,
+            },
+            callback: function (r) {
+              if (r.message === "success") {
+                frappe.msgprint(
+                  __("All linked records have been successfully deleted.")
+                );
+                frappe.set_route("List", "Sales Order");
+              } else {
+                frappe.throw(
+                  __("An error occurred while deleting linked records.")
+                );
+              }
+            },
+          });
+        }
+      );
+    });
+  }
+}


### PR DESCRIPTION
## Issue description
Not able to delete a sales order because it's various links

## Solution description
unlink and delete the sales order step by step

## Output screenshots
[Screencast from 15-10-24 10:24:00 AM IST.webm](https://github.com/user-attachments/assets/f60bab4d-185a-40ad-8087-eb2bac82ea37)

## Areas affected and ensured
Sales Order

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
