### PR TITLE
fix: removed payment creation button froms sales order

### DIFF
--- a/one_compliance/public/js/sales_order.js
+++ b/one_compliance/public/js/sales_order.js
@@ -26,7 +26,9 @@ frappe.ui.form.on('Sales Order', {
         frm.remove_custom_button('Request for Raw Materials', 'Create');
         frm.remove_custom_button('Purchase Order', 'Create');
         frm.remove_custom_button('Project', 'Create');
-        frm.remove_custom_button('Payment', 'Create');
+        if (frappe.user_roles.incudes("Accounts User") || frappe.user_roles.incudes("Accounts Manager")) {
+          frm.remove_custom_button('Payment', 'Create');
+        }
         }, 500);
     }
 });

--- a/one_compliance/public/js/sales_order.js
+++ b/one_compliance/public/js/sales_order.js
@@ -26,6 +26,7 @@ frappe.ui.form.on('Sales Order', {
         frm.remove_custom_button('Request for Raw Materials', 'Create');
         frm.remove_custom_button('Purchase Order', 'Create');
         frm.remove_custom_button('Project', 'Create');
+        frm.remove_custom_button('Payment', 'Create');
         }, 500);
     }
 });


### PR DESCRIPTION
## Issue description
Hide payment creation button from SO.

## Solution description
Remove Payment button from Create Group

## Output screenshots
![image](https://github.com/user-attachments/assets/ec83a7dd-9f1a-4367-959d-74f05f52e49d)

## Areas affected and ensured
Sales Order - js

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
