### PR TITLE
fix: setting the patch for workflow states to only run with existing …

### DIFF
--- a/one_compliance/patches.txt
+++ b/one_compliance/patches.txt
@@ -1,1 +1,6 @@
+[pre_model_sync]
+# These patches will run pre doctype sync
+
+[post_model_sync]
+# These patches will run post doctype sync
 one_compliance.patches.v15.so_workflow_cancel_state 2024-08-28test1

--- a/one_compliance/patches/v15/so_workflow_cancel_state.py
+++ b/one_compliance/patches/v15/so_workflow_cancel_state.py
@@ -1,4 +1,10 @@
 import frappe
 
+
 def execute():
-    frappe.db.sql("""UPDATE `tabSales Order` SET workflow_state = 'Cancelled' WHERE docstatus=2""")
+    if frappe.db.exists("Sales Order", {"docstatus": "2"}) and hasattr(
+        frappe.new_doc("Sales Order"), "workflow_state"
+    ):
+        frappe.db.sql(
+            """UPDATE `tabSales Order` SET workflow_state = 'Cancelled' WHERE docstatus=2"""
+        )


### PR DESCRIPTION
…data

## Issue description
Patch to set workflow states for Sales Order is causing issues on new sites and before migrate

## Solution description
Set the patch to only work on conditions and after doctypes are synced.

## Output screenshots 
![image](https://github.com/user-attachments/assets/daf89ac0-8dbe-44ee-af0c-2e94f32e5e2f)

## Areas affected and ensured
Patches

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
