### PR TITLE
feat: adding tasks in project template

### DIFF
--- a/one_compliance/public/js/project_template.js
+++ b/one_compliance/public/js/project_template.js
@@ -1,7 +1,13 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
 
 frappe.ui.form.on('Project Template', {
     setup: function(frm) {
         set_filters(frm)
+        restrict_task_field(frm);
+    },
+    custom_add_tasks(frm) {
+        new_task_popup(frm);
     }
 });
 
@@ -101,4 +107,111 @@ function documents_required_primary_action(frm, values, child){
             }
         }
     });
+}
+
+/**
+ * The functions below are used to show a popup that will add a task into the task table and disable adding rows the native way
+ *
+ */
+function restrict_task_field(frm){
+    frm.fields_dict.tasks.grid.update_docfield_property('task', 'only_select', 1);
+    frm.set_df_property('tasks', 'cannot_add_rows', true);
+    frappe.model.get_children(frm.doc, "tasks").forEach(e=>{
+        frappe.meta.get_docfield('Project Template Task', 'task', e.name).only_select = true;
+    })
+}
+
+function new_task_popup(frm){
+    let primary_action_label = 'Create & Add';
+    let dialog = new frappe.ui.Dialog({
+        title: 'Task details',
+        fields: [
+            {
+                label: 'Is Existing Task',
+                fieldname: 'is_existing_task',
+                fieldtype: 'Check',
+                change: () => {
+                    let is_existing_task = dialog.get_value('is_existing_task');
+                    if(is_existing_task){
+                        primary_action_label = 'Add';
+                    }
+                    else {
+                        primary_action_label = 'Create & Add';
+                    }
+                    set_primary_action_label(dialog, primary_action_label)
+                }
+            },
+            {
+                label: 'Task',
+                fieldname: 'task',
+                fieldtype: 'Link',
+                options: 'Task',
+                only_select: 1,
+                get_query: function(){
+                    return {
+                        filters: {
+                            is_template: 1
+                        }
+                    }
+                },
+                depends_on: 'eval: doc.is_existing_task',
+                mandatory_depends_on: 'eval: doc.is_existing_task',
+                change: () => {
+                    let task = dialog.get_value('task');
+                    frappe.db.get_value('Task', task, 'subject').then(r => {
+                        if(r.message.subject){
+                            dialog.set_value('subject', r.message.subject);
+                        }
+                        else {
+                            dialog.set_value('subject', );
+                        }
+                    });
+                }
+            },
+            {
+                label: 'Subject',
+                fieldname: 'subject',
+                fieldtype: 'Data',
+                depends_on: 'eval: !doc.is_existing_task',
+                mandatory_depends_on: 'eval: !doc.is_existing_task',
+            }
+        ],
+        primary_action_label: primary_action_label,
+        primary_action(values) {
+            if(values.is_existing_task){
+                add_task_row(frm, values.task, values.subject)
+            }
+            else {
+                create_task(frm, values.subject);
+            }
+            dialog.hide();
+        }
+    });
+    dialog.show();
+}
+
+function create_task(frm, subject){
+    frappe.db.insert({
+        doctype: 'Task',
+        subject: subject,
+        is_template: 1,
+        status: 'Template'
+    }).then(doc => {
+        if(doc.name){
+            add_task_row(frm, doc.name, subject)
+        }
+    });
+}
+
+function add_task_row(frm, task, subject){
+    frm.add_child('tasks',{
+        'task': task,
+        'subject': subject
+    });
+    frm.refresh_field('tasks');
+    restrict_task_field(frm);
+}
+
+function set_primary_action_label(dialog, primary_action_label) {
+    dialog.get_primary_btn().removeClass("hide").html(primary_action_label);
 }


### PR DESCRIPTION
## Feature description
Adding tasks to the project template made easier.

## Solution description
Removed adding rows to task table and added a button which shows a popup that will accept task data

## Screenshots
![image](https://github.com/user-attachments/assets/d4458c0b-d061-4ecc-b648-84131f2d34b5)

## Areas affected and ensured
Project Template

## Is there any existing behavior change of other features due to this code change?
Yes, No longer will the user be able to add rows natively in task table in project template

## Was this feature tested on the browsers?
Chrome: Yes
