### PR TITLE
feat:Fetched Sales Order in Payment Entry from Project

### DIFF
--- a/one_compliance/setup.py
+++ b/one_compliance/setup.py
@@ -28,6 +28,8 @@ def create_custom_fields_for_app():
     create_custom_fields(get_task_custom_fields())
     create_custom_fields(get_terms_and_conditions_custom_fields())
     create_custom_fields(get_timesheet_custom_fields())
+    create_custom_fields(get_payment_entry_custom_fields())
+
 
 
 def delete_custom_fields_for_app():
@@ -46,6 +48,8 @@ def delete_custom_fields_for_app():
     delete_custom_fields(get_task_custom_fields())
     delete_custom_fields(get_terms_and_conditions_custom_fields())
     delete_custom_fields(get_timesheet_custom_fields())
+    delete_custom_fields(get_payment_entry_custom_fields())
+
 
 
 def create_fixtures():
@@ -123,6 +127,24 @@ def insert_doc(doc_list, doctype=None):
                     )
     except Exception as e:
         frappe.log_error("Error during migration", e)
+
+
+
+def get_payment_entry_custom_fields():
+    return {
+        "Payment Entry": [
+            {
+
+                "fieldname": "sales_order",
+                "fieldtype": "Data",
+                "label": "Sales Order",
+                "insert_after": "project",
+                "fetch_from":"project.sales_order",
+                "read_only": 1
+            }
+         
+        ]
+    }
 
 
 def get_timesheet_custom_fields():

--- a/one_compliance/setup.py
+++ b/one_compliance/setup.py
@@ -131,19 +131,33 @@ def insert_doc(doc_list, doctype=None):
 
 
 def get_payment_entry_custom_fields():
-    return {
-        "Payment Entry": [
-            {
+    project_meta = frappe.get_meta("Project")
 
-                "fieldname": "sales_order",
-                "fieldtype": "Data",
-                "label": "Sales Order",
-                "insert_after": "project",
-                "fetch_from":"project.sales_order",
-                "read_only": 1
-            }
-         
-        ]
+    fields = []
+    
+    if project_meta.has_field("sales_order"):
+        fields.append({
+            "fieldname": "sales_order",
+            "fieldtype": "Data",
+            "label": "Sales Order",
+            "insert_after": "project",
+            "fetch_from": "project.sales_order",
+            "read_only": 1
+
+        })
+
+    if project_meta.has_field("customer"):
+        fields.append({
+            "fieldname": "customer",
+            "fieldtype": "Data",
+            "label": "Client",
+            "insert_after": "cost_center",
+            "fetch_from": "project.customer",
+            "read_only": 1
+        })
+
+    return {
+        "Payment Entry": fields
     }
 
 


### PR DESCRIPTION
## Feature description
Fetch sales order of Project in Payment Entry.

## Solution description
A new field Sales Order is added.
When Project is selected in Payment Entry the corresponding Sales order is fetched in sales order field.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/b49505a4-dcce-4a99-bf96-1d122170cf4e)

## Areas affected and ensured
Payment Entry doctype.

## Is there any existing behavior change of other features due to this code change?
     No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

