### PR TITLE
fix: If outward only is checked no need of inward register

### DIFF
--- a/one_compliance/one_compliance/doctype/outward_register/outward_register.py
+++ b/one_compliance/one_compliance/doctype/outward_register/outward_register.py
@@ -6,19 +6,24 @@ from frappe.model.document import Document
 
 class OutwardRegister(Document):
 
-	def on_submit(self):
-		self.update_inward_child_table()
+    def on_submit(self):
+        if not self.if_outward_only:
+            self.update_inward_child_table()
 
-	def update_inward_child_table(self):
-		''' Method to update status of Inward child table based on Outward child table '''
-		inward_doc = frappe.get_doc('Inward Register', self.inward_register)
-		for document_types in self.document_register_type:
-			document_doc = document_types.document_register_type
-			for register_types in inward_doc.register_type_detail:
-				if register_types.document_register_type == document_doc:
-					register_types.status = 'Returned'
-					register_types.outward_register = self.name
-		inward_doc.save()
+    def update_inward_child_table(self):
+        """ Method to update status of Inward child table based on Outward child table """
+        if not self.inward_register:
+            return
+
+        inward_doc = frappe.get_doc('Inward Register', self.inward_register)
+        for document_types in self.document_register_type:
+            document_doc = document_types.document_register_type
+            for register_types in inward_doc.register_type_detail:
+                if register_types.document_register_type == document_doc:
+                    register_types.status = 'Returned'
+                    register_types.outward_register = self.name
+        inward_doc.save()
+
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Issue Description : 
- If outward only is checked then no need of inward register

Solution description : 
- Only access inward register details if outward is unchecked

Output : 
![image](https://github.com/user-attachments/assets/127b7974-25d5-4a36-b700-77baedd12cf5)
![image](https://github.com/user-attachments/assets/dd5759a6-592e-42da-b1d0-36b1be6b7b2c)

