### PR TITLE
    TASK-2025-00638:Prevent clearing of Project ID when task is marked as completed

### DIFF
--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
@@ -36,23 +36,33 @@ function make_filters(page) {
 		}
   });
 	let projectField = page.add_field({
-		label: __("Project"),
-		fieldname: "project",
-		fieldtype: "Link",
-		options: "Project",
-		default:project_id,
-		change() {
-			if (page.fields_dict.project.get_value()) {
-          refresh_tasks(page);
-      }
-		}
-	});
-	localStorage.removeItem('selected_project_id');
-	page.fields_dict.project.$input.on('change', function() {
-		if (!page.fields_dict.project.get_value()) {
+	label: __("Project"),
+	fieldname: "project",
+	fieldtype: "Link",
+	options: "Project",
+	default: project_id,
+	change() {
+		let project = page.fields_dict.project.get_value();
+		if (project) {
 			refresh_tasks(page);
+			// Keep the selected project id after refresh
+			localStorage.setItem('selected_project_id', project);
 		}
-  });
+	}
+});
+
+let stored_project = localStorage.getItem('selected_project_id');
+if (stored_project && !page.fields_dict.project.get_value()) {
+	page.fields_dict.project.set_value(stored_project);
+}
+
+page.fields_dict.project.$input.on('change', function() {
+	if (!page.fields_dict.project.get_value()) {
+		refresh_tasks(page);
+		// You may remove selected_project_id here
+		localStorage.removeItem('selected_project_id');
+	}
+});
 	let customerField = page.add_field({
 		label: __("Customer"),
 		fieldname: "customer",


### PR DESCRIPTION
## Feature description
     -Updated logic to ensure that marking a task as completed does not clear or reset the associated Project ID in the Project Management Tool.
     -Ensured that the Project ID remains intact even after the task status is updated to 'Completed'.

## Solution description
     -Project ID was retained when task was marked as completed

## Output screenshots (optional)
[Screencast from 21-04-25 01:55:01 PM IST.webm](https://github.com/user-attachments/assets/d57c367f-6c61-4415-b003-77db0d2640c4)

## Areas affected and ensured
     -Project Management Tool

## Is there any existing behavior change of other features due to this code change?
     -No. 

## Was this feature tested on the browsers?
     -Mozilla Firefox
  