### PR TITLE
fix : Project management tool visibility change to if status != Compl…

### DIFF
--- a/one_compliance/one_compliance/page/project_management_tool/project_management_tool.py
+++ b/one_compliance/one_compliance/page/project_management_tool/project_management_tool.py
@@ -15,7 +15,7 @@ def get_project(status=None, project=None, customer=None, department=None, sub_c
     INNER JOIN
         tabTask t ON t.project = p.name
     WHERE
-        t.status = 'Open'
+        t.status != 'Completed'
     """
 
     if status:


### PR DESCRIPTION

## Issue description
- If a task with status rather complete exist then visible the project in project management tool

## Solution description
- Change the query status = open in to status not = completed 


