### PR TITLE
TASK-2025-00956: Need to set status of the task based on the set project status button

### DIFF
--- a/one_compliance/one_compliance/doctype/digital_signature/digital_signature.json
+++ b/one_compliance/one_compliance/doctype/digital_signature/digital_signature.json
@@ -43,6 +43,7 @@
    "fieldtype": "Password",
    "in_list_view": 1,
    "label": "Digital Signature Key",
+   "no_copy": 1,
    "reqd": 1
   },
   {
@@ -169,7 +170,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-11-14 16:04:01.848379",
+ "modified": "2025-05-13 14:36:32.342560",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Digital Signature",


### PR DESCRIPTION

## Issue description
1.  need to implement When Clicking "Set Project Status"button and changing the Status to "Hold", Tasks are changing to "Hold" status. But Project status is not Changing. in project doctype 
2. Also the completed task  must not change to "Hold" status 
3. Bring a Eye Icon in "Digital Signature Key" field. in digital signature doctype

## Solution description
1.implemented while set the hold status in set project button project status is changed to hold 
2. completed task are not set to hold 
3 added eye icon in the field digital signature key field in the digital signature
## Output screenshots (optional)
[Screencast from 13-05-25 02:50:36 PM IST.webm](https://github.com/user-attachments/assets/913be62e-79a1-4ad1-87d7-a0a3b1af0e93)
![image](https://github.com/user-attachments/assets/85992cc5-4da2-419e-a5e8-79912e8d3d64)
![image](https://github.com/user-attachments/assets/e3dfd34b-9dc3-450e-955a-070854222d4e)


## Areas affected and ensured
project and digital signature doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
 
  - Mozilla Firefox
