### PR TITLE
feat:Added field in Sales Order

### DIFF
--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -237,6 +237,7 @@ def create_sales_order_from_event(event, customer=None, sub_category=None, rate=
     sub_category_doc = frappe.get_doc("Compliance Sub Category", sub_category)
     new_sales_order = frappe.new_doc("Sales Order")
     new_sales_order.customer = customer
+    new_sales_order.event = event
     new_sales_order.posting_date = frappe.utils.today()
     new_sales_order.delivery_date = frappe.utils.today()
     new_sales_order.append('items', {

--- a/one_compliance/setup.py
+++ b/one_compliance/setup.py
@@ -2721,6 +2721,14 @@ def get_sales_order_custom_fields():
                 "unique": 0,
                 "width": None,
             },
+            {
+                "fieldname": "event",
+                "fieldtype": "Link",
+                "label": "Event",
+                "insert_after": "custom_total_reimbursement_amount",
+                "options": "Event",
+                "read_only": 1
+            },
         ]
     }
 


### PR DESCRIPTION
## Feature description

- Add Field in Sales Order.

## Solution description

- Added field named "Event" in Sales Order.
- When creating performa invoice from event , mark the event reference in that field.

## Output screenshots (optional)
<img width="958" alt="Screenshot 2025-05-15 at 11 39 43 AM" src="https://github.com/user-attachments/assets/d05f8418-4670-4464-897e-f107e8ed52bc" />


## Areas affected and ensured
`one_compliance/setup.py`
`one_compliance/one_compliance/doc_events/sales_order.py`

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome