### PR TITLE
TASK-2025-00983: Need to list all project while assigned based on is project

### DIFF
--- a/one_compliance/one_compliance/doctype/project_reassign/project_reassign.json
+++ b/one_compliance/one_compliance/doctype/project_reassign/project_reassign.json
@@ -1,0 +1,68 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-05-15 12:53:43.537495",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "project",
+  "project_name",
+  "client",
+  "compliance_sub_category",
+  "status"
+ ],
+ "fields": [
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Project",
+   "options": "Project"
+  },
+  {
+   "fieldname": "client",
+   "fieldtype": "Data",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Client"
+  },
+  {
+   "fieldname": "compliance_sub_category",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Compliance Sub Category ",
+   "options": "Compliance Sub Category"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Data",
+   "label": "Status"
+  },
+  {
+   "fieldname": "project_name",
+   "fieldtype": "Data",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Project Name "
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-05-15 13:08:31.947187",
+ "modified_by": "Administrator",
+ "module": "One Compliance",
+ "name": "Project Reassign",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/one_compliance/one_compliance/doctype/project_reassign/project_reassign.py
+++ b/one_compliance/one_compliance/doctype/project_reassign/project_reassign.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class ProjectReassign(Document):
+	pass

--- a/one_compliance/one_compliance/doctype/task_bulk_assignment/task_bulk_assignment.json
+++ b/one_compliance/one_compliance/doctype/task_bulk_assignment/task_bulk_assignment.json
@@ -13,12 +13,12 @@
   "from_date",
   "column_break_lwccr",
   "assignment_based_on",
-  "project",
   "assigned_to",
   "status",
   "to_date",
   "task_reassigns_section",
   "task_reassigns",
+  "project_reassigns",
   "column_break_x0pun",
   "assign_to"
  ],
@@ -37,6 +37,7 @@
    "label": "Task Reassigning Entries"
   },
   {
+   "depends_on": "eval: doc.assignment_based_on == \"Task\"",
    "fieldname": "task_reassigns",
    "fieldtype": "Table",
    "label": "Task Reassigns",
@@ -94,13 +95,6 @@
    "options": "Task\nProject"
   },
   {
-   "depends_on": "eval: doc.assignment_based_on == \"Project\";",
-   "fieldname": "project",
-   "fieldtype": "Link",
-   "label": "Project",
-   "options": "Project"
-  },
-  {
    "fieldname": "from_date",
    "fieldtype": "Date",
    "label": "From Date"
@@ -109,13 +103,20 @@
    "fieldname": "to_date",
    "fieldtype": "Date",
    "label": "To Date"
+  },
+  {
+   "depends_on": "eval: doc.assignment_based_on == \"Project\"",
+   "fieldname": "project_reassigns",
+   "fieldtype": "Table",
+   "label": "Project Reassigns",
+   "options": "Project Reassign"
   }
  ],
  "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-02-26 11:14:37.205363",
+ "modified": "2025-05-19 09:41:40.027446",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Task Bulk Assignment",


### PR DESCRIPTION
## Feature description
1. Need Tasks must be able view by Administrator and other role, only Executive and Manager need the restriction to see their assigned Task only.
2.  need to implement Template, Cancelled and Completed Task must not appear to any user.
3.  need to implement When selecting Assignment Based on Project the "project reassign" table must list out all the Projects that has status of Open,Hold and Overdue.
4. need to implement Remove Project field and its validations and related code.

## Solution description
1. administrator can see all task even the administrator is  executive and manager 
2. implement the task are listed not in the template, cancelled,and completed
3. while selecting the assigned  based on is project the listed in the project reassign is listed 
 created new child table project reassign 
4. removed the project field and related code 
## Output screenshots (optional)
[Screencast from 19-05-25 02:18:11 PM IST.webm](https://github.com/user-attachments/assets/565f80e9-ad86-4e72-b9c8-b21fa2d5ea80)


## Areas affected and ensured
task bulk assignment doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  
  - Mozilla Firefox
 
