### PR TITLE
    TASK-2025-00585 : POP Next Task Based on Previous Task Completion

### DIFF
--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -132,12 +132,14 @@ doc_events = {
             'one_compliance.one_compliance.doc_events.task.task_on_update',
             'one_compliance.one_compliance.doc_events.task.make_sales_invoice',
             'one_compliance.one_compliance.doc_events.task.subtask_on_update',
+            'one_compliance.one_compliance.doc_events.task.on_task_update',
         ],
         'validate':[
             'one_compliance.one_compliance.doc_events.task.append_users_to_project',
             'one_compliance.one_compliance.doc_events.task.set_task_status_to_hold',
         ],
-        'autoname': 'one_compliance.one_compliance.doc_events.task.autoname'
+        'autoname': 'one_compliance.one_compliance.doc_events.task.autoname',
+        'after_insert':'one_compliance.one_compliance.doc_events.task.set_task_readiness_flow_on_creation',
     },
     'Project':{
         'on_update': 'one_compliance.one_compliance.doc_events.project.project_on_update',

--- a/one_compliance/one_compliance/page/project_management_tool/project_management_tool.py
+++ b/one_compliance/one_compliance/page/project_management_tool/project_management_tool.py
@@ -3,6 +3,7 @@ from frappe.utils import get_datetime
 
 @frappe.whitelist()
 def get_project(status=None, project=None, customer=None, department=None, sub_category=None, employee=None, from_date=None, to_date=None):
+    current_user = frappe.session.user
     user_id = f'"{employee}"' if employee else None
 
     # Construct SQL query to fetch list of projects that have at least one task with 'Open' status
@@ -15,8 +16,12 @@ def get_project(status=None, project=None, customer=None, department=None, sub_c
     INNER JOIN
         tabTask t ON t.project = p.name
     WHERE
-        t.status != 'Completed'
+        1 = 1
     """
+    if current_user != "Administrator":
+        query += " AND t.status != 'Completed' AND t.readiness_status = 'Ready'"
+        if employee:
+            query += f" AND t._assign LIKE '%{user_id}%'"
 
     if status:
         query += f" AND p.status = '{status}'"

--- a/one_compliance/public/js/task.js
+++ b/one_compliance/public/js/task.js
@@ -1,6 +1,12 @@
 frappe.ui.form.on('Task',{
   refresh(frm){
-    let roles = frappe.user_roles;
+    let roles = frappe.user_roles;    
+    // Make the field 'readiness_status' read-only if the user has the 'Executive' role
+    if (roles.includes('Executive')) {
+      frm.set_df_property('readiness_status', 'read_only', 1);
+    } else {
+      frm.set_df_property('readiness_status', 'read_only', 0);
+    }
     if(roles.includes('Compliance Manager') || roles.includes('Director')){
       if(!frm.is_new() && frm.doc.is_template == 0){
         frm.add_custom_button('View Credential', () => {
@@ -23,9 +29,30 @@ frappe.ui.form.on('Task',{
       frm.set_df_property('is_group','hidden',1);
       frm.set_df_property('is_template','hidden',1);
     }
+    update_readiness_status_field(frm);
   }
 });
 /* applied dialog instance to show customer Credential */
+
+// Function to update readiness_status visibility based on project_template's enable_task_readiness_flow
+function update_readiness_status_field(frm) {
+  if (frm.doc.compliance_sub_category) {
+    frappe.db.get_value('Compliance Sub Category', frm.doc.compliance_sub_category, 'project_template', (r) => {
+      if (r && r.project_template) {
+        // Fetch the enable_task_readiness_flow field from the linked project_template
+        frappe.db.get_value('Project Template', r.project_template, 'enable_task_readiness_flow', (result) => {
+          if (result && result.enable_task_readiness_flow) {
+            // If enable_task_readiness_flow is checked, show the readiness_status field
+            frm.fields_dict.readiness_status.$wrapper.show();
+          } else {
+            // If enable_task_readiness_flow is not checked, hide the readiness_status field
+            frm.fields_dict.readiness_status.$wrapper.hide();
+          }
+        });
+      }
+    });
+  }
+}
 
 let customer_credentials = function (frm) {
   frappe.db.get_value('Project', frm.doc.project, 'customer')

--- a/one_compliance/setup.py
+++ b/one_compliance/setup.py
@@ -510,6 +510,14 @@ def get_task_custom_fields():
                 "width": None,
             },
             {
+                "fieldname":"readiness_status",
+                "fieldtype":"Select",
+                "label":"Readiness Status",
+                "options":"Not Ready\nReady",
+                "in_list_view":1,
+                "insert_after":"status"
+            },
+            {
                 "_assign": None,
                 "_comments": None,
                 "_liked_by": None,
@@ -3948,6 +3956,12 @@ def get_project_template_custom_fields():
                 "translatable": 0,
                 "unique": 0,
                 "width": None,
+            },
+            {
+                "fieldname":"enable_task_readiness_flow",
+                "fieldtype":"Check",
+                "label":"Enable Task Readiness Flow",
+                "insert_after":"custom_project_duration"
             },
             {
                 "_assign": None,


### PR DESCRIPTION
## Feature description
-  Add a checkbox enable_task_readiness_flow in project template
  - Add a select field Readiness Flow in Task
   -If a project template with enable_task_readiness_flow checked then set the status ready automatically as previous task is completed
- Administrator can see all project in project management tool assigned employee can see whenever readiness status become 
ready 
## Solution description
As the project template has checked the readiness the the creation of task set first one as ready on completion next one status changed to ready and so on
- implemented Administrator can see all project in project management tool assigned employee can see whenever readiness status become ready 
## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/758249c4-4232-4106-bc39-49710e758309)
![image](https://github.com/user-attachments/assets/e59cbc48-d032-4be5-94b0-c6409a1f3786)
![image](https://github.com/user-attachments/assets/323b7833-51cb-4573-89ed-052eea28033e)
[Screencast from 20-05-25 02:33:39 PM IST.webm](https://github.com/user-attachments/assets/a0b71362-78a3-4264-b82f-82853e615665)

## Areas affected and ensured 
project management tool and  task management tool doctype

## Is there any existing behavior change of other features due to this code change?
 No. 
## Was this feature tested on the browsers?
  
  - Mozilla Firefox
  
