### PR TITLE
fix: Change Report name of Project compliance agreement link to Missing Project Summary

### DIFF
--- a/one_compliance/one_compliance/report/missing_project_summary/missing_project_summary.js
+++ b/one_compliance/one_compliance/report/missing_project_summary/missing_project_summary.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-frappe.query_reports["Project Compliance  Agreement Link Report"] = {
+frappe.query_reports["Missing Project Summary"] = {
 	"filters": [
 		{
             "fieldname": "customer",

--- a/one_compliance/one_compliance/report/missing_project_summary/missing_project_summary.json
+++ b/one_compliance/one_compliance/report/missing_project_summary/missing_project_summary.json
@@ -1,27 +1,36 @@
 {
  "add_total_row": 0,
+ "add_translate_data": 0,
  "columns": [],
- "creation": "2025-05-21 12:13:55.644438",
+ "creation": "2025-06-06 11:09:17.906131",
  "disabled": 0,
  "docstatus": 0,
  "doctype": "Report",
  "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "json": "{}",
  "letterhead": null,
- "modified": "2025-05-23 10:14:05.043348",
+ "modified": "2025-06-06 11:09:17.906131",
  "modified_by": "Administrator",
  "module": "One Compliance",
- "name": "Project Compliance  Agreement Link Report",
+ "name": "Missing Project Summary",
  "owner": "Administrator",
  "prepared_report": 0,
  "ref_doctype": "Project",
- "report_name": "Project Compliance  Agreement Link Report",
+ "report_name": "Missing Project Summary",
  "report_type": "Script Report",
  "roles": [
   {
-   "role": "System Manager"
+   "role": "Projects Manager"
+  },
+  {
+   "role": "Projects User"
+  },
+  {
+   "role": "Employee"
+  },
+  {
+   "role": "Employee Self Service"
   }
  ],
  "timeout": 0

--- a/one_compliance/one_compliance/report/missing_project_summary/missing_project_summary.py
+++ b/one_compliance/one_compliance/report/missing_project_summary/missing_project_summary.py
@@ -41,7 +41,7 @@ def get_missing_projects(filters):
     valid_date_fields = {
         "Valid From": "ca.valid_from",
         "Valid Upto": "ca.valid_upto",
-        "Posting Date": "ca.posting_date"  
+        "Posting Date": "ca.posting_date"
     }
     date_basis_field = valid_date_fields.get(date_basis)
     if from_date and to_date and date_basis_field:
@@ -142,6 +142,3 @@ def get_repeat_dates(start_date, valid_upto, frequency, month=None, day=None):
                                         6 if frequency == "Half Yearly" else
                                         12)
     return dates
-
-
-


### PR DESCRIPTION
## Feature description
- Change report name of Project compliance agreement link to Missing Project Summary.

## Solution description
- Changed report name of Project Compliance agreement to Missing Project Summary.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/8c9fb44a-1e2b-49e8-8bcc-55286c301960)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
