### PR TITLE
feat : Adding remove option in Task assigning tool

### DIFF
--- a/one_compliance/one_compliance/doctype/task_assigning_tool/task_assigning_tool.js
+++ b/one_compliance/one_compliance/doctype/task_assigning_tool/task_assigning_tool.js
@@ -2,6 +2,77 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Task Assigning Tool', {
+
+	assignment_type: function(frm) {
+    if (frm.doc.assignment_type === "Remove") {
+      frm.toggle_display('employee', true);
+      frm.toggle_display('assign_from', false);
+      frm.toggle_display('assign_to', false);
+      frm.toggle_display('assign', false);
+    } else if (frm.doc.assignment_type === "Transfer") {
+      frm.toggle_display('employee', false);
+      frm.toggle_display('assign_from', true);
+      frm.toggle_display('assign_to', true);
+      frm.toggle_display('assign', true);
+    }
+    clear_values(frm);
+  },
+
+  employee: function(frm) {
+    if (frm.doc.assignment_type === "Remove" && frm.doc.employee) {
+      frappe.call({
+        method: 'one_compliance.one_compliance.doctype.task_assigning_tool.task_assigning_tool.get_tasks_for_user',
+        args: {
+          assign_from: frm.doc.employee,
+					assignment_type: frm.doc.assignment_type
+        },
+        callback: function(r) {
+          if (r.message) {
+						frm.clear_table('assigned_tasks');
+						r.message.forEach(task => {
+						  let assigned_task = frm.add_child('assigned_tasks');
+						  assigned_task.task_id = task.task_id;
+						  assigned_task.subject = task.subject;
+						  assigned_task.project = task.project;
+						});
+						frm.refresh_field('assigned_tasks');
+          }
+        }
+      });
+    }
+  },
+
+	remove_assignment_btn: function(frm) {
+	  if (!frm.doc.employee) {
+	    frappe.msgprint("Please select an employee.");
+	    return;
+	  }
+
+	  let selectedTaskIds = frm.doc.assigned_tasks.map(row => row.task_id);
+
+	  if (selectedTaskIds.length === 0) {
+	    frappe.msgprint("No tasks found to remove.");
+	    return;
+	  }
+
+	  frappe.call({
+	    method: "one_compliance.one_compliance.doctype.task_assigning_tool.task_assigning_tool.remove_task_assignments",
+	    args: {
+	      employee: frm.doc.employee,
+	      selected_tasks_json: JSON.stringify(selectedTaskIds)
+	    },
+	    freeze: true,
+	    freeze_message: "Removing task assignments...",
+	    callback: function(r) {
+	      if (r.message === "Assignments removed successfully") {
+	        frappe.msgprint("Assignments removed successfully.");
+	        frm.trigger("employee"); // re-fetch tasks for selected employee
+	      } else {
+	        frappe.msgprint("Some error occurred while removing tasks.");
+	      }
+	    }
+	  });
+	},
 	refresh: function(frm) {
     frm.disable_save();
 		frm.toggle_display('add_to_subcategories', false);

--- a/one_compliance/one_compliance/doctype/task_assigning_tool/task_assigning_tool.json
+++ b/one_compliance/one_compliance/doctype/task_assigning_tool/task_assigning_tool.json
@@ -33,18 +33,31 @@
    "options": "Department"
   },
   {
-   "depends_on": "eval: doc.assignment_type == 'Assign'",
+   "depends_on": "eval: doc.assignment_type == 'Assign'|| doc.assignment_type == 'Remove'",
    "fieldname": "employee",
    "fieldtype": "Link",
    "label": "Employee",
    "options": "User"
   },
   {
+    "depends_on": "eval: doc.assignment_type == 'Remove' && doc.employee",
+    "fieldname": "assigned_tasks",
+    "fieldtype": "Table",
+    "label": "Assigned Tasks",
+    "options": "Task Reassign"
+  },
+  {
    "fieldname": "assignment_type",
    "fieldtype": "Select",
    "label": "Assignment Type",
-   "options": "\nTransfer\nAssign",
+   "options": "\nTransfer\nAssign\nRemove",
    "reqd": 1
+  },
+  {
+    "fieldname": "remove_assignment_btn",
+    "fieldtype": "Button",
+    "label": "Remove Assignment",
+    "depends_on": "eval: doc.assignment_type == 'Remove' && doc.employee"
   },
   {
    "fieldname": "column_break_w0gtb",
@@ -91,7 +104,7 @@
    "label": "Assign"
   },
   {
-   "depends_on": "eval: doc.employee",
+   "depends_on": "eval: doc.employee && doc.assignment_type == 'Assign'",
    "fieldname": "compliance_categories",
    "fieldtype": "Link",
    "label": "Compliance Categories",

--- a/one_compliance/one_compliance/doctype/task_assigning_tool/task_assigning_tool.py
+++ b/one_compliance/one_compliance/doctype/task_assigning_tool/task_assigning_tool.py
@@ -37,7 +37,7 @@ def get_users_by_department(doctype, txt, searchfield, start, page_len, filters)
     return user_info_list  # Return the list of email IDs and full names as tuples
 
 @frappe.whitelist()
-def get_tasks_for_user(assign_from):
+def get_tasks_for_user(assign_from, assignment_type=None):
     # Query tasks from the ToDo doctype
     tasks = frappe.get_all('ToDo', filters={'allocated_to': assign_from, 'status': 'Open'}, fields=['reference_type', 'reference_name', 'description'])
 
@@ -57,7 +57,8 @@ def get_tasks_for_user(assign_from):
                     'subject': task_details_query[0]['subject'],
                     'project': task_details_query[0]['project']
                 })
-        elif reference_type == 'Project':
+        elif reference_type == 'Project' and assignment_type != 'Remove':
+
             # Fetch task details from the Task doctype based on the project_name
             tasks_for_project = frappe.get_all('Task', filters={'project': reference_id}, fields=['name', 'project', 'subject'])
             project_task_details = []
@@ -236,3 +237,30 @@ def add_to_subcategories(employee, compliance_category, selected_subcategories):
     except Exception as e:
         frappe.log_error(frappe.get_traceback(), _("Error in adding employee to Compliance Sub Categories"))
         return False
+
+@frappe.whitelist()
+def remove_task_assignments(employee, selected_tasks_json):
+    import json
+    selected_tasks = json.loads(selected_tasks_json)
+
+    try:
+        for task_id in selected_tasks:
+            # Get ToDos for the given employee and task
+            todos = frappe.get_all("ToDo", filters={
+                "reference_type": "Task",
+                "reference_name": task_id,
+                "allocated_to": employee,
+                "status": "Open"
+            }, fields=["name"])
+
+            # Cancel each ToDo (no need to touch Task.assigned_to)
+            for todo in todos:
+                todo_doc = frappe.get_doc("ToDo", todo.name)
+                todo_doc.status = "Cancelled"
+                todo_doc.save(ignore_permissions=True)
+
+        frappe.db.commit()
+        return "Assignments removed successfully"
+
+    except Exception:
+        return "Error occurred while removing assignments"


### PR DESCRIPTION
## Feature description

- Add option remove in task assigning tool 
- On clicking remove button remove all the assigned task for the particular employee

## Solution description

- Added remove option in assignment type 
- Assigned Task are listed in the table
- On clicking remove but all the todos are cancelled 

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/1cd17fdb-2466-4a79-b553-00789cb8bd9f)
![image](https://github.com/user-attachments/assets/c7ac10a8-43e3-4530-a417-d30e5a2989e2)
![image](https://github.com/user-attachments/assets/958627c2-f239-4740-bfc2-20f7482425b1)



