### PR TITLE
So from opp

### DIFF
--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -166,6 +166,7 @@ doc_events = {
         'on_submit':'one_compliance.one_compliance.doc_events.sales_order.create_project_on_submit',
         'on_cancel': 'one_compliance.one_compliance.doc_events.sales_order.so_on_cancel_custom',
         'on_update_after_submit': 'one_compliance.one_compliance.doc_events.sales_order.so_on_update_after_submit',
+        'validate': 'one_compliance.one_compliance.doc_events.sales_order.set_compliance_fields'
     },
     'Payment Entry':{
         'on_submit': 'one_compliance.one_compliance.doc_events.payment_entry.payment_entry_on_submit'
@@ -194,7 +195,8 @@ scheduler_events = {
         'one_compliance.one_compliance.utils.notification_for_digital_signature_expiry',
         'one_compliance.one_compliance.utils.project_overdue_notification',
         'one_compliance.one_compliance.doc_events.project.set_status_to_overdue',
-        'one_compliance.one_compliance.doctype.compliance_sub_category.compliance_sub_category.send_repeat_notif'
+        'one_compliance.one_compliance.doctype.compliance_sub_category.compliance_sub_category.send_repeat_notif',
+        'one_compliance.one_compliance.doc_events.sales_order.create_opportunity"'
     ],
 #	"hourly": [
 #		"one_compliance.tasks.hourly"

--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -196,7 +196,7 @@ scheduler_events = {
         'one_compliance.one_compliance.utils.project_overdue_notification',
         'one_compliance.one_compliance.doc_events.project.set_status_to_overdue',
         'one_compliance.one_compliance.doctype.compliance_sub_category.compliance_sub_category.send_repeat_notif',
-        'one_compliance.one_compliance.doc_events.sales_order.create_opportunity"'
+        'one_compliance.one_compliance.doc_events.sales_order.create_opportunity'
     ],
 #	"hourly": [
 #		"one_compliance.tasks.hourly"

--- a/one_compliance/one_compliance/doc_events/oppotunity.py
+++ b/one_compliance/one_compliance/doc_events/oppotunity.py
@@ -51,8 +51,6 @@ def set_opportunity_converted(doc, method):
 	if opportunity_name:
 		frappe.db.set_value('Opportunity', opportunity_name, 'status', 'Converted')
 
-
-
 @frappe.whitelist()
 def create_sales_order(opportunity):
     if not frappe.db.exists('Opportunity', opportunity):

--- a/one_compliance/one_compliance/doc_events/oppotunity.py
+++ b/one_compliance/one_compliance/doc_events/oppotunity.py
@@ -66,7 +66,9 @@ def create_sales_order(opportunity):
             "item_name": i.item_name,
             "uom": i.uom,
             "qty": i.qty,
-            "rate": i.rate
+            "rate": i.rate,
+            "custom_compliance_category": i.compliance_category,
+			"custom_compliance_subcategory": i.compliance_sub_category,
         })
 
     return {

--- a/one_compliance/one_compliance/doc_events/oppotunity.py
+++ b/one_compliance/one_compliance/doc_events/oppotunity.py
@@ -1,6 +1,8 @@
 import frappe
 from frappe.model.mapper import *
 from frappe import _
+from frappe.utils import getdate, today, get_link_to_form
+
 
 @frappe.whitelist()
 def make_engagement_letter(source_name,target_name=None):
@@ -48,3 +50,44 @@ def set_opportunity_converted(doc, method):
 
 	if opportunity_name:
 		frappe.db.set_value('Opportunity', opportunity_name, 'status', 'Converted')
+
+
+
+@frappe.whitelist()
+def create_sales_order(opportunity):
+    if not frappe.db.exists('Opportunity', opportunity):
+        frappe.throw("Opportunity not found")
+
+    opp = frappe.get_doc('Opportunity', opportunity)
+    customer = create_if_customer_not_exists(opp)
+
+    items = []
+    for i in opp.items:
+        items.append({
+            "item_code": i.item_code,
+            "item_name": i.item_name,
+            "uom": i.uom,
+            "qty": i.qty,
+            "rate": i.rate
+        })
+
+    return {
+        "customer": customer,
+        "items": items
+    }
+
+def create_if_customer_not_exists(opp):
+    if opp.opportunity_from == 'Customer':
+        return opp.party_name
+
+    existing = frappe.db.get_value('Customer', {'opportunity_name': opp.name})
+    if existing:
+        return existing
+
+    customer = frappe.new_doc('Customer')
+    customer.opportunity_name = opp.name
+    customer.customer_name = opp.contact_person or "Unnamed Customer"
+    customer.compliance_customer_type = opp.custom_customer_type or frappe.db.get_single_value("Compliance Settings", "customer_type")
+    customer.flags.ignore_mandatory = True
+    customer.save(ignore_permissions=True)
+    return customer.name

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -320,154 +320,157 @@ def delete_linked_records(sales_order):
 
 @frappe.whitelist()
 def create_opportunity():
-    """
-    Creates Opportunities for Sales Orders flagged for follow_up_for_next_project
-    and assigns a Task to follow_up_person from Compliance Sub Category
-    """
-    today_date = getdate(today())
-    this_year = today_date.year
-    this_month = today_date.month
+	"""
+	Creates Opportunities for Sales Orders flagged for follow_up_for_next_project
+	and assigns a Task to follow_up_person from Compliance Sub Category
+	"""
+	today_date = getdate(today())
+	this_year = today_date.year
+	this_month = today_date.month
 
-    print(f"[INFO] Today's Date: {today_date}")
+	print(f"[INFO] Today's Date: {today_date}")
 
-    sales_orders = frappe.db.get_all(
-        "Sales Order",
-        filters={"follow_up_for_next_project": 1},
-        fields=["name", "customer"]
-    )
+	sales_orders = frappe.db.get_all(
+		"Sales Order",
+		filters={"follow_up_for_next_project": 1},
+		fields=["name", "customer", "status", "workflow_state"]
+	)
 
-    for so in sales_orders:
-        sales_order_items = frappe.get_all(
-            "Sales Order Item",
-            filters={"parent": so.name},
-            fields=["custom_compliance_subcategory"]
-        )
+	for so in sales_orders:
+		sales_order_items = frappe.db.get_all(
+			"Sales Order Item",
+			filters={"parent": so.name},
+			fields=["custom_compliance_subcategory"]
+		)
 
-        for item in sales_order_items:
-            subcat_name = item.custom_compliance_subcategory
-            if not subcat_name:
-                continue
+		for item in sales_order_items:
+			subcat_name = item.custom_compliance_subcategory
+			if not subcat_name:
+				continue
 
-            compliance = frappe.get_doc("Compliance Sub Category", subcat_name)
+			compliance = frappe.get_doc("Compliance Sub Category", subcat_name)
 
-            if not (compliance.allow_repeat and compliance.renew_notif):
-                continue
+			if not (compliance.allow_repeat and compliance.renew_notif):
+				continue
 
-            day = int(compliance.day or 1)
-            notif_days = int(float(compliance.renew_notif_days_before or 0))
-            repeat_on = compliance.repeat_on
-            scheduled_date = None
+			day = int(compliance.day or 1)
+			notif_days = int(float(compliance.renew_notif_days_before or 0))
+			repeat_on = compliance.repeat_on
+			scheduled_date = None
 
-            try:
-                if repeat_on == "Monthly":
-                    scheduled_date = datetime(this_year, this_month, day).date()
+			try:
+				if repeat_on == "Monthly":
+					scheduled_date = datetime(this_year, this_month, day).date()
 
-                elif repeat_on == "Quarterly":
-                    for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
-                        d = datetime(this_year, m, day).date()
-                        if d >= today_date:
-                            scheduled_date = d
-                            break
+				elif repeat_on == "Quarterly":
+					for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
+						d = datetime(this_year, m, day).date()
+						if d >= today_date:
+							scheduled_date = d
+							break
 
-                elif repeat_on == "Half Yearly":
-                    for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
-                        d = datetime(this_year, m, day).date()
-                        if d >= today_date:
-                            scheduled_date = d
-                            break
+				elif repeat_on == "Half Yearly":
+					for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
+						d = datetime(this_year, m, day).date()
+						if d >= today_date:
+							scheduled_date = d
+							break
 
-                elif repeat_on == "Yearly":
-                    if compliance.month:
-                        m = datetime.strptime(compliance.month, "%B").month
-                        scheduled_date = datetime(this_year, m, day).date()
+				elif repeat_on == "Yearly":
+					if compliance.month:
+						m = datetime.strptime(compliance.month, "%B").month
+						scheduled_date = datetime(this_year, m, day).date()
 
-            except Exception as e:
-                print(f"[WARN] Skipping {subcat_name}: Invalid date - {e}")
-                continue
+			except Exception as e:
+				print(f"[WARN] Skipping {subcat_name}: Invalid date - {e}")
+				continue
 
-            if not scheduled_date:
-                continue
+			if not scheduled_date:
+				continue
 
-            notif_trigger_date = add_days(scheduled_date, -notif_days)
-            print(f"[DEBUG] For {subcat_name}: Scheduled on {scheduled_date}, Notify on {notif_trigger_date}")
+			notif_trigger_date = add_days(scheduled_date, -notif_days)
+			print(f"[DEBUG] For {subcat_name}: Scheduled on {scheduled_date}, Notify on {notif_trigger_date}")
 
-            if notif_trigger_date != today_date:
-                continue
+			if notif_trigger_date != today_date:
+				continue
 
-            existing_opportunity = frappe.db.exists("Opportunity", {"sales_order": so.name})
-            if existing_opportunity:
-                print(f"[SKIP] Opportunity already exists for Sales Order: {so.name}")
-                continue
+			existing_opportunity = frappe.db.exists("Opportunity", {"sales_order": so.name})
+			if existing_opportunity:
+				print(f"[SKIP] Opportunity already exists for Sales Order: {so.name}")
+				continue
 
-            try:
-                opportunity = frappe.new_doc("Opportunity")
-                opportunity.opportunity_from = "Customer"
-                opportunity.party_name = so.customer
-                opportunity.status = "Open"
-                opportunity.opportunity_type = "Sales"
-                opportunity.sales_order = so.name
-                opportunity.naming_series = "CRM-OPP-.YYYY.-"
-                opportunity.company = frappe.db.get_single_value("Global Defaults", "default_company")
+			try:
+       
+				if so.status not in ["Draft", "Closed", "Cancelled"] or so.workflow_state not in ["Pending", "Cancelled"]:
+					frappe.log_error(so.status, so.workflow_state)
+					opportunity = frappe.new_doc("Opportunity")
+					opportunity.opportunity_from = "Customer"
+					opportunity.party_name = so.customer
+					opportunity.status = "Open"
+					opportunity.opportunity_type = "Sales"
+					opportunity.sales_order = so.name
+					opportunity.naming_series = "CRM-OPP-.YYYY.-"
+					opportunity.company = frappe.db.get_single_value("Global Defaults", "default_company")
 
-                opportunity.insert(ignore_permissions=True)
-                frappe.db.commit()
+					opportunity.insert(ignore_permissions=True)
+					frappe.db.commit()
 
-                print(f"[SUCCESS] Created Opportunity: {opportunity.name} for {subcat_name}")
+					print(f"[SUCCESS] Created Opportunity: {opportunity.name} for {subcat_name}")
 
-                # Create and assign Task
-                follow_up_user = frappe.db.get_value("Employee", compliance.follow_up_person, "user_id")
-                
-                if follow_up_user:
-                    try:
-                        task = frappe.new_doc("Task")
-                        task.subject = f"Follow up on Opportunity {opportunity.name}"
-                        task.reference_type = "Opportunity"
-                        task.reference_name = opportunity.name
-                        task.status = "Open"
-                        task.description = f"Follow up for compliance sub category: {subcat_name}"
-                        task.assigned_by = frappe.session.user
-                        task.company = opportunity.company
+					# Create and assign Task
+					follow_up_user = frappe.db.get_value("Employee", compliance.follow_up_person, "user_id")
 
-                        task.insert(ignore_permissions=True)
-                        frappe.db.commit()
+					try:
+						task = frappe.new_doc("Task")
+						task.subject = f"Follow up on Opportunity {opportunity.name}"
+						task.reference_type = "Opportunity"
+						task.reference_name = opportunity.name
+						task.status = "Open"so
+						task.description = f"Follow up for compliance sub category: {subcat_name}"
+						task.assigned_by = frappe.session.user
+						task.company = opportunity.company
 
-                        todo = frappe.new_doc("ToDo")
-                        todo.owner = follow_up_user
-                        todo.assigned_by = frappe.session.user
-                        todo.allocated_to = follow_up_user
-                        todo.reference_type = "Task"
-                        todo.reference_name = task.name
-                        todo.description = f"Follow up for compliance sub category: {subcat_name}"
-                        todo.status = "Open"
-                        todo.priority = "Medium"
-                        todo.date = today()
-                        todo.insert(ignore_permissions=True)
-                        frappe.db.commit()
+						task.insert(ignore_permissions=True)
+						frappe.db.commit()
 
-                        print(f"[SUCCESS] Created and assigned Task {task.name} to {follow_up_user}")
+						if follow_up_user:
+							todo = frappe.new_doc("ToDo")
+							todo.owner = follow_up_user
+							todo.assigned_by = frappe.session.user
+							todo.allocated_to = follow_up_user
+							todo.reference_type = "Task"
+							todo.reference_name = task.name
+							todo.description = f"Follow up for compliance sub category: {subcat_name}"
+							todo.status = "Open"
+							todo.priority = "Medium"
+							todo.date = today()
+							todo.insert(ignore_permissions=True)
+							frappe.db.commit()
 
-                    except Exception as e:
-                        print(f"[ERROR] Failed to create/assign Task for {subcat_name}: {e}")
+						print(f"[SUCCESS] Created and assigned Task {task.name} to {follow_up_user}")
 
-            except Exception as e:
-                print(f"[ERROR] Failed to create opportunity for {subcat_name}: {e}")
+					except Exception as e:
+						print(f"[ERROR] Failed to create/assign Task for {subcat_name}: {e}")
+
+			except Exception as e:
+				print(f"[ERROR] Failed to create opportunity for {subcat_name}: {e}")
 
 
 
 
 def set_compliance_fields(doc, method):
-    """
-    For each item , this function fetches the related compliance category 
-    and subcategory 
-    """
-    for item in doc.items:
-        if item.item_code:
-           subcat =  frappe.db.get_value(
+	"""
+	For each item , this function fetches the related compliance category 
+	and subcategory 
+	"""
+	for item in doc.items:
+		if item.item_code:
+			subcat =  frappe.db.get_value(
 				"Compliance Sub Category",
-                 {"item_code": item.item_code},
-                 ["compliance_category", "name"],
-                 as_dict=True
+				 {"item_code": item.item_code},
+				 ["compliance_category", "name"],
+				 as_dict=True
 			)
-           if subcat:
-               item.custom_compliance_category     = subcat.compliance_category
-               item.custom_compliance_subcategory  = subcat.name
+			if subcat:
+				item.custom_compliance_category     = subcat.compliance_category
+				item.custom_compliance_subcategory  = subcat.name

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -423,7 +423,7 @@ def create_opportunity():
 						task.subject = f"Follow up on Opportunity {opportunity.name}"
 						task.reference_type = "Opportunity"
 						task.reference_name = opportunity.name
-						task.status = "Open",
+						task.status = "Open"
 						task.description = f"Follow up for compliance sub category: {subcat_name}"
 						task.assigned_by = frappe.session.user
 						task.company = opportunity.company

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -1,13 +1,16 @@
+from datetime import datetime
+
 import frappe
 from frappe import _
-from frappe.utils import add_days, add_months, date_diff, getdate, json
+from frappe.utils import add_days, add_months, date_diff, getdate, json, today
 from one_compliance.one_compliance.utils import add_custom as add_assign
 from one_compliance.one_compliance.utils import create_todo, get_users_with_role
 
 
+
 @frappe.whitelist()
 def update_journal_entry(doc):
-	if doc.custom_reimbursement_details:
+	if doc.custom_reimbursement_details:	
 		for reimbursement_detail in doc.custom_reimbursement_details:
 			if frappe.db.exists('Journal Entry', reimbursement_detail.journal_entry):
 				entry_doc = frappe.get_doc('Journal Entry', reimbursement_detail.journal_entry)
@@ -310,3 +313,154 @@ def delete_linked_records(sales_order):
 	frappe.delete_doc("Sales Order", sales_order, ignore_permissions=True)
 
 	return "success"
+
+
+
+
+@frappe.whitelist()
+def create_opportunity():
+    """
+    Creates Opportunities for Sales Orders flagged for follow_up_for_next_project
+    and assigns a Task to follow_up_person from Compliance Sub Category
+    """
+    today_date = getdate(today())
+    this_year = today_date.year
+    this_month = today_date.month
+
+    print(f"[INFO] Today's Date: {today_date}")
+
+    sales_orders = frappe.db.get_all(
+        "Sales Order",
+        filters={"follow_up_for_next_project": 1},
+        fields=["name", "customer"]
+    )
+
+    for so in sales_orders:
+        sales_order_items = frappe.get_all(
+            "Sales Order Item",
+            filters={"parent": so.name},
+            fields=["custom_compliance_subcategory"]
+        )
+
+        for item in sales_order_items:
+            subcat_name = item.custom_compliance_subcategory
+            if not subcat_name:
+                continue
+
+            compliance = frappe.get_doc("Compliance Sub Category", subcat_name)
+
+            if not (compliance.allow_repeat and compliance.renew_notif):
+                continue
+
+            day = int(compliance.day or 1)
+            notif_days = int(float(compliance.renew_notif_days_before or 0))
+            repeat_on = compliance.repeat_on
+            scheduled_date = None
+
+            try:
+                if repeat_on == "Monthly":
+                    scheduled_date = datetime(this_year, this_month, day).date()
+
+                elif repeat_on == "Quarterly":
+                    for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
+                        d = datetime(this_year, m, day).date()
+                        if d >= today_date:
+                            scheduled_date = d
+                            break
+
+                elif repeat_on == "Half Yearly":
+                    for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
+                        d = datetime(this_year, m, day).date()
+                        if d >= today_date:
+                            scheduled_date = d
+                            break
+
+                elif repeat_on == "Yearly":
+                    if compliance.month:
+                        m = datetime.strptime(compliance.month, "%B").month
+                        scheduled_date = datetime(this_year, m, day).date()
+
+            except Exception as e:
+                print(f"[WARN] Skipping {subcat_name}: Invalid date - {e}")
+                continue
+
+            if not scheduled_date:
+                continue
+
+            notif_trigger_date = add_days(scheduled_date, -notif_days)
+            print(f"[DEBUG] For {subcat_name}: Scheduled on {scheduled_date}, Notify on {notif_trigger_date}")
+
+            if notif_trigger_date != today_date:
+                continue
+
+            existing_opportunity = frappe.db.exists("Opportunity", {"sales_order": so.name})
+            if existing_opportunity:
+                print(f"[SKIP] Opportunity already exists for Sales Order: {so.name}")
+                continue
+
+            try:
+                opportunity = frappe.new_doc("Opportunity")
+                opportunity.opportunity_from = "Customer"
+                opportunity.party_name = so.customer
+                opportunity.status = "Open"
+                opportunity.opportunity_type = "Sales"
+                opportunity.sales_order = so.name
+                opportunity.naming_series = "CRM-OPP-.YYYY.-"
+                opportunity.company = frappe.db.get_single_value("Global Defaults", "default_company")
+
+                opportunity.insert(ignore_permissions=True)
+                frappe.db.commit()
+
+                print(f"[SUCCESS] Created Opportunity: {opportunity.name} for {subcat_name}")
+
+                # Create and assign Task
+                follow_up_user = frappe.db.get_value("Employee", compliance.follow_up_person, "user_id")
+                
+                if follow_up_user:
+                    try:
+                        task = frappe.new_doc("Task")
+                        task.subject = f"Follow up on Opportunity {opportunity.name}"
+                        task.reference_type = "Opportunity"
+                        task.reference_name = opportunity.name
+                        task.status = "Open"
+                        task.description = f"Follow up for compliance sub category: {subcat_name}"
+                        task.assigned_by = frappe.session.user
+                        task.company = opportunity.company
+
+                        task.insert(ignore_permissions=True)
+                        frappe.db.commit()
+
+                        add_assign({
+							"assign_to": follow_up_user,
+                            "doctype": "Task",
+                            "name": task.name,
+                            "description": f"Follow up for compliance sub category: {subcat_name}"
+						})
+
+                        print(f"[SUCCESS] Created and assigned Task {task.name} to {follow_up_user}")
+
+                    except Exception as e:
+                        print(f"[ERROR] Failed to create/assign Task for {subcat_name}: {e}")
+
+            except Exception as e:
+                print(f"[ERROR] Failed to create opportunity for {subcat_name}: {e}")
+
+
+
+
+def set_compliance_fields(doc, method):
+    """
+    For each item , this function fetches the related compliance category 
+    and subcategory 
+    """
+    for item in doc.items:
+        if item.item_code:
+           subcat =  frappe.db.get_value(
+				"Compliance Sub Category",
+                 {"item_code": item.item_code},
+                 ["compliance_category", "name"],
+                 as_dict=True
+			)
+           if subcat:
+               item.custom_compliance_category     = subcat.compliance_category
+               item.custom_compliance_subcategory  = subcat.name

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -5,6 +5,7 @@ from frappe import _
 from frappe.utils import add_days, add_months, date_diff, getdate, json, today
 from one_compliance.one_compliance.utils import add_custom as add_assign
 from one_compliance.one_compliance.utils import create_todo, get_users_with_role
+from frappe.desk.form.assign_to import add
 
 
 
@@ -430,12 +431,18 @@ def create_opportunity():
                         task.insert(ignore_permissions=True)
                         frappe.db.commit()
 
-                        add_assign({
-							"assign_to": follow_up_user,
-                            "doctype": "Task",
-                            "name": task.name,
-                            "description": f"Follow up for compliance sub category: {subcat_name}"
-						})
+                        todo = frappe.new_doc("ToDo")
+                        todo.owner = follow_up_user
+                        todo.assigned_by = frappe.session.user
+                        todo.allocated_to = follow_up_user
+                        todo.reference_type = "Task"
+                        todo.reference_name = task.name
+                        todo.description = f"Follow up for compliance sub category: {subcat_name}"
+                        todo.status = "Open"
+                        todo.priority = "Medium"
+                        todo.date = today()
+                        todo.insert(ignore_permissions=True)
+                        frappe.db.commit()
 
                         print(f"[SUCCESS] Created and assigned Task {task.name} to {follow_up_user}")
 

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -315,7 +315,6 @@ def delete_linked_records(sales_order):
 
 
 
-
 @frappe.whitelist()
 def create_opportunity():
 	"""
@@ -328,6 +327,7 @@ def create_opportunity():
 
 	print(f"[INFO] Today's Date: {today_date}")
 
+	# Get all eligible Sales Orders
 	sales_orders = frappe.db.get_all(
 		"Sales Order",
 		filters={"follow_up_for_next_project": 1},
@@ -335,19 +335,27 @@ def create_opportunity():
 	)
 
 	for so in sales_orders:
-		sales_order_items = frappe.db.get_all(
+		# Fetch Sales Order Items with compliance fields
+		sales_order_items = frappe.get_all(
 			"Sales Order Item",
 			filters={"parent": so.name},
-			fields=["custom_compliance_subcategory"]
+			fields=[
+				"item_code", "item_name", "uom", "qty",
+				"brand", "item_group", "description",
+				"image", "base_rate", "base_amount", "rate", "amount",
+				"custom_compliance_subcategory as compliance_sub_category",
+				"custom_compliance_category as compliance_category"
+			]
 		)
 
 		for item in sales_order_items:
-			subcat_name = item.custom_compliance_subcategory
+			subcat_name = item.compliance_sub_category
 			if not subcat_name:
 				continue
 
 			compliance = frappe.get_doc("Compliance Sub Category", subcat_name)
 
+			# Only if repeat + notifications allowed
 			if not (compliance.allow_repeat and compliance.renew_notif):
 				continue
 
@@ -392,15 +400,15 @@ def create_opportunity():
 			if notif_trigger_date != today_date:
 				continue
 
+			# Skip if Opportunity already exists
 			existing_opportunity = frappe.db.exists("Opportunity", {"sales_order": so.name})
 			if existing_opportunity:
 				print(f"[SKIP] Opportunity already exists for Sales Order: {so.name}")
 				continue
 
 			try:
-       
+				# Only create for active sales orders
 				if so.status not in ["Draft", "Closed", "Cancelled"] or so.workflow_state not in ["Pending", "Cancelled"]:
-					frappe.log_error(so.status, so.workflow_state)
 					opportunity = frappe.new_doc("Opportunity")
 					opportunity.opportunity_from = "Customer"
 					opportunity.party_name = so.customer
@@ -409,6 +417,26 @@ def create_opportunity():
 					opportunity.sales_order = so.name
 					opportunity.naming_series = "CRM-OPP-.YYYY.-"
 					opportunity.company = so.company
+
+					# Map Sales Order Items → Opportunity Items
+					for soi in sales_order_items:
+						opp_item = opportunity.append("items", {})
+						opp_item.item_code = soi.item_code
+						opp_item.item_name = soi.item_name
+						opp_item.uom = soi.uom
+						opp_item.qty = soi.qty
+						opp_item.brand = soi.brand
+						opp_item.item_group = soi.item_group
+						opp_item.description = soi.description
+						opp_item.image = soi.image
+						opp_item.base_rate = soi.base_rate
+						opp_item.base_amount = soi.base_amount
+						opp_item.rate = soi.rate
+						opp_item.amount = soi.amount
+
+						# Map compliance fields to Opportunity Item
+						opp_item.compliance_category = soi.compliance_category
+						opp_item.compliance_sub_category = soi.compliance_sub_category
 
 					opportunity.insert(ignore_permissions=True)
 					frappe.db.commit()
@@ -454,8 +482,6 @@ def create_opportunity():
 				print(f"[ERROR] Failed to create opportunity for {subcat_name}: {e}")
 
 
-
-
 def set_compliance_fields(doc, method):
 	"""
 	For each item , this function fetches the related compliance category 
@@ -472,3 +498,5 @@ def set_compliance_fields(doc, method):
 			if subcat:
 				item.custom_compliance_category     = subcat.compliance_category
 				item.custom_compliance_subcategory  = subcat.name
+    
+    

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -331,7 +331,7 @@ def create_opportunity():
 	sales_orders = frappe.db.get_all(
 		"Sales Order",
 		filters={"follow_up_for_next_project": 1},
-		fields=["name", "customer", "status", "workflow_state"]
+		fields=["name", "customer", "status", "workflow_state", "company"]
 	)
 
 	for so in sales_orders:
@@ -408,7 +408,7 @@ def create_opportunity():
 					opportunity.opportunity_type = "Sales"
 					opportunity.sales_order = so.name
 					opportunity.naming_series = "CRM-OPP-.YYYY.-"
-					opportunity.company = frappe.db.get_single_value("Global Defaults", "default_company")
+					opportunity.company = so.company
 
 					opportunity.insert(ignore_permissions=True)
 					frappe.db.commit()

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -5,8 +5,6 @@ from frappe import _
 from frappe.utils import add_days, add_months, date_diff, getdate, json, today
 from one_compliance.one_compliance.utils import add_custom as add_assign
 from one_compliance.one_compliance.utils import create_todo, get_users_with_role
-from frappe.desk.form.assign_to import add
-
 
 
 @frappe.whitelist()
@@ -425,7 +423,7 @@ def create_opportunity():
 						task.subject = f"Follow up on Opportunity {opportunity.name}"
 						task.reference_type = "Opportunity"
 						task.reference_name = opportunity.name
-						task.status = "Open"so
+						task.status = "Open",
 						task.description = f"Follow up for compliance sub category: {subcat_name}"
 						task.assigned_by = frappe.session.user
 						task.company = opportunity.company

--- a/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.json
+++ b/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.json
@@ -27,7 +27,7 @@
   "internal",
   "is_billable",
   "rate",
-  "follow_up_required",
+  "follow_up_person",
   "section_break_qmwb",
   "default_account",
   "department_details_section",
@@ -292,15 +292,15 @@
    "options": "Email Template"
   },
   {
-   "default": "0",
-   "fieldname": "follow_up_required",
-   "fieldtype": "Check",
-   "label": "Follow up Required"
+   "fieldname": "follow_up_person",
+   "fieldtype": "Link",
+   "label": "Follow up Person",
+   "options": "Employee"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-04 09:32:24.946131",
+ "modified": "2025-07-04 14:22:32.826835",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Compliance Sub Category",

--- a/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.json
+++ b/one_compliance/one_compliance/doctype/compliance_sub_category/compliance_sub_category.json
@@ -27,6 +27,7 @@
   "internal",
   "is_billable",
   "rate",
+  "follow_up_required",
   "section_break_qmwb",
   "default_account",
   "department_details_section",
@@ -289,11 +290,17 @@
    "fieldtype": "Link",
    "label": "Renew Notification for Customer",
    "options": "Email Template"
+  },
+  {
+   "default": "0",
+   "fieldname": "follow_up_required",
+   "fieldtype": "Check",
+   "label": "Follow up Required"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-10 11:25:17.649914",
+ "modified": "2025-07-04 09:32:24.946131",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Compliance Sub Category",

--- a/one_compliance/public/js/opportunity.js
+++ b/one_compliance/public/js/opportunity.js
@@ -123,40 +123,6 @@ function create_event(frm) {
 }
 
 
-// function make_buttons(frm){
-//     if(!frm.is_new() && frm.doc.status != 'Converted'){
-//         let confirmation_msg = 'System will create a Customer and Sales Order. Are you sure you want to proceed?';
-//         if (frm.doc.opportunity_from == 'Customer'){
-//             confirmation_msg = 'System will create a Sales Order. Are you sure you want to proceed?'
-//         }
-//         frm.add_custom_button('Sales Order', () => {
-//             if(!frm.doc.items.length){
-//                 frm.scroll_to_field('items');
-//                 frappe.dom.unfreeze();
-//                 frappe.throw({message:__("Please fill the `Services` before creating Sales Order."), title: __("Missing fields")});
-//             }
-//             else {
-//                 frappe.confirm(confirmation_msg,
-//                     () => {
-//                         // action to perform if Yes is selected
-//                         frappe.call('one_compliance.one_compliance.doc_events.oppotunity.create_sales_order', {
-//                             opportunity: frm.doc.name
-//                         }).then(r => {
-//                             frm.reload_doc()
-//                         })
-//                     }, () => {
-//                         // action to perform if No is selected
-//                         frappe.show_alert({
-//                             message: __('Action reverted'),
-//                             indicator: 'orange'
-//                         }, 5);
-//                 })
-//             }
-//         }, 'Create'); 
-//     }
-// }
-
-
 
 
 function make_buttons(frm){

--- a/one_compliance/public/js/opportunity.js
+++ b/one_compliance/public/js/opportunity.js
@@ -12,6 +12,8 @@ frappe.ui.form.on('Opportunity',{
             frm.add_custom_button('Create Event',() =>{
                 create_event(frm)
             });
+
+            make_buttons(frm);
         }
     },
     make_engagement_letter: function (frm) {
@@ -118,4 +120,82 @@ function create_event(frm) {
         }
     });
     d.show();
+}
+
+
+// function make_buttons(frm){
+//     if(!frm.is_new() && frm.doc.status != 'Converted'){
+//         let confirmation_msg = 'System will create a Customer and Sales Order. Are you sure you want to proceed?';
+//         if (frm.doc.opportunity_from == 'Customer'){
+//             confirmation_msg = 'System will create a Sales Order. Are you sure you want to proceed?'
+//         }
+//         frm.add_custom_button('Sales Order', () => {
+//             if(!frm.doc.items.length){
+//                 frm.scroll_to_field('items');
+//                 frappe.dom.unfreeze();
+//                 frappe.throw({message:__("Please fill the `Services` before creating Sales Order."), title: __("Missing fields")});
+//             }
+//             else {
+//                 frappe.confirm(confirmation_msg,
+//                     () => {
+//                         // action to perform if Yes is selected
+//                         frappe.call('one_compliance.one_compliance.doc_events.oppotunity.create_sales_order', {
+//                             opportunity: frm.doc.name
+//                         }).then(r => {
+//                             frm.reload_doc()
+//                         })
+//                     }, () => {
+//                         // action to perform if No is selected
+//                         frappe.show_alert({
+//                             message: __('Action reverted'),
+//                             indicator: 'orange'
+//                         }, 5);
+//                 })
+//             }
+//         }, 'Create'); 
+//     }
+// }
+
+
+
+
+function make_buttons(frm){
+    if (!frm.is_new() && frm.doc.status !== 'Converted') {
+        let msg = 'System will create a Customer and Sales Order. Proceed?';
+        if (frm.doc.opportunity_from === 'Customer') {
+            msg = 'System will create a Sales Order. Proceed?';
+        }
+
+        frm.add_custom_button('Sales Order', () => {
+            if (!frm.doc.items.length) {
+                frm.scroll_to_field('items');
+                frappe.throw({
+                    message: __("Please fill the `Services` before creating Sales Order."),
+                    title: __("Missing fields")
+                });
+            }
+
+            frappe.confirm(msg, () => {
+                frappe.call({
+                    method: 'one_compliance.one_compliance.doc_events.oppotunity.create_sales_order',
+                    args: { opportunity: frm.doc.name },
+                    callback: (r) => {
+                        if (!r.exc) {
+                            const d = r.message;
+                            frappe.model.with_doctype('Sales Order', () => {
+                                const doc = frappe.model.get_new_doc('Sales Order');
+                                doc.customer = d.customer;
+                                doc.opportunity = frm.doc.name;
+                                d.items.forEach(i => {
+                                    let row = frappe.model.add_child(doc, 'items');
+                                    Object.assign(row, i);
+                                });
+                                frappe.set_route('Form', 'Sales Order', doc.name);
+                            });
+                        }
+                    }
+                });
+            });
+        }, 'Create');
+    }
 }

--- a/one_compliance/setup.py
+++ b/one_compliance/setup.py
@@ -29,6 +29,7 @@ def create_custom_fields_for_app():
     create_custom_fields(get_terms_and_conditions_custom_fields())
     create_custom_fields(get_timesheet_custom_fields())
     create_custom_fields(get_todo_custom_fields())
+    create_custom_fields(get_opportunity_item_custom_fields())
 
 
 def delete_custom_fields_for_app():
@@ -14609,3 +14610,26 @@ def get_todo_custom_fields():
             }
         ]
     }
+
+
+def get_opportunity_item_custom_fields():
+	return {
+		"Opportunity Item": [
+			{
+				"fieldname": "compliance_category",
+				"label": "Compliance Category",
+				"fieldtype": "Link",
+				"options": "Compliance Category",
+				"insert_after": "item_code",
+				"in_list_view": 1,
+			},
+			{
+				"fieldname": "compliance_sub_category",
+				"label": "Compliance Sub Category",
+				"fieldtype": "Link",				
+				"options": "Compliance Sub Category",		
+				"insert_after": "compliance_category",
+				"in_list_view": 1,	
+			}
+		]
+}

--- a/one_compliance/setup.py
+++ b/one_compliance/setup.py
@@ -2747,6 +2747,12 @@ def get_sales_order_custom_fields():
                 "options": "Event",
                 "read_only": 1
             },
+            {
+                "fieldname": "follow_up_for_next_project",
+                "fieldtype": "Check",
+                "label": "Follow up for next Project",
+                "insert_after": "custom_create_project_automatically"
+            }
         ]
     }
 
@@ -5013,6 +5019,13 @@ def get_opportunity_custom_fields():
                 "unique": 0,
                 "width": None,
             },
+            {
+                "fieldname": "sales_order",
+                "fieldtype": "Link",
+                "label": "Sales Order",
+                "insert_after": "annual_revenue",
+                "options": "Sales Order"
+            }
         ]
     }
 

--- a/one_compliance/setup.py
+++ b/one_compliance/setup.py
@@ -5026,7 +5026,13 @@ def get_opportunity_custom_fields():
                 "label": "Sales Order",
                 "insert_after": "annual_revenue",
                 "options": "Sales Order"
-            }
+            },
+            {
+				"fieldname": "follow_up_reply",
+				"fieldtype": "Small Text",
+				"label": "Follow up Reply",			
+				"insert_after": "notes_html"
+			}
         ]
     }
 


### PR DESCRIPTION
## Feature description
Create Opportunity from Sales Order

1. Bring a field “Followup for next Project” (checkbox) in Sales Order.
2. The Compliance Sub Category  have a field “Send Renew Notification to Customer”, based on this date a new opportunity 
    has to be created for the Customer
4. Add a checkbox “Followup Required” in Compliance Sub Category.
5.  A task has  to be created to the Opportunity to follow up the Customer. Assign this task to the Employee in the Project                       
      Template of this Compliance Sub Category. (Bring a new field “Follow up Person” in compliance Sub category)


## Solution description
Enabled opportunity and Task creation  from sales order if Followup for next Project checkbox is checked in sales order for that compliance category and task is assigned to the follow up person in compliance category.

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![image](https://github.com/user-attachments/assets/ab6de5ed-a402-47e0-8ac0-7affd403afe1)
![image](https://github.com/user-attachments/assets/ad16c5e6-d3e3-4476-be06-39f88741d39b)
![image](https://github.com/user-attachments/assets/f8dc5107-f6ce-4fac-8ac7-eb2abb165a21)



## Was this feature tested on the browsers?
  - Chrome
