### PR TITLE
fix: Compliance Agreement

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
@@ -364,6 +364,13 @@ def create_project_against_sub_category(compliance_agreement, compliance_sub_cat
 							create_todo('Task', task_doc.name, employee.user_id, employee.user_id, 'Task {0} Assigned Successfully'.format(task_doc.name))
 
 		frappe.db.commit()
+		agreement_doc = frappe.get_doc('Compliance Agreement', compliance_agreement)
+		for row in agreement_doc.compliance_category_details:
+			if row.name == compliance_category_details_id:
+				row.project = project.name
+
+		agreement_doc.save(ignore_permissions=True)
+		frappe.db.commit()		
 	else:
 		frappe.throw( title = _('ALERT !!'), msg = _('Project Template does not exist for {0}'.format(compliance_sub_category)))
 

--- a/one_compliance/one_compliance/doctype/compliance_category_details/compliance_category_details.json
+++ b/one_compliance/one_compliance/doctype/compliance_category_details/compliance_category_details.json
@@ -9,6 +9,7 @@
  "field_order": [
   "compliance_category",
   "compliance_date",
+  "project",
   "column_break_yy2oq",
   "compliance_sub_category",
   "sub_category_name",
@@ -69,17 +70,26 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Sub Category Name"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Project",
+   "options": "Project"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-19 11:06:47.364243",
+ "modified": "2025-07-19 14:08:28.547486",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Compliance Category Details",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
## Feature description
- Compliance Date has to be updated after every action regarding the Project creation is completed
- Bring a new field "Project" in "Compliance Category Details". This field must show the lates Project created.

## Solution description
- Compliance Date has to be updated after every action regarding the Project creation is completed
- Bring a new field "Project" in "Compliance Category Details". This field must show the lates Project created.

## Output screenshots (optional)
<img width="1346" height="640" alt="image" src="https://github.com/user-attachments/assets/5a31bfe0-fbc1-42c5-b51a-11e336bc9e86" />

## Is there any existing behavior change of other features due to this code change?
No.
## Was this feature tested on the browsers?
  - Mozilla Firefox