### PR TITLE
feat: track lag_time of  task

### DIFF
--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
@@ -683,6 +683,12 @@ function showTimeEntryDialog(page, taskName, projectName, assignees, startTime) 
                 reqd: true,
 								read_only: 1,
 								default: toTime
+            },
+            {
+                label: __("Lag Time"),
+                fieldname: "lag_time",
+                fieldtype: 'Duration',
+
             }
         ],
         primary_action: function (values) {
@@ -697,7 +703,8 @@ function showTimeEntryDialog(page, taskName, projectName, assignees, startTime) 
 										employee: values.employee,
 										activity: values.activity,
 										from_time: values.from_time,
-										to_time: values.to_time
+										to_time: values.to_time,
+                                        lag_time: values.lag_time,
 								},
 								callback: function (r) {
 										frappe.msgprint("Timesheet created successfully!");

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
@@ -92,7 +92,7 @@ def get_task(status = None, task = None, project = None, customer = None, depart
     return task_list
 
 @frappe.whitelist()
-def create_timesheet(project, task, employee, activity, from_time, to_time):
+def create_timesheet(project, task, employee, activity, from_time, to_time, lag_time=None):
 
     from_time = get_datetime(from_time)
     to_time = get_datetime(to_time)
@@ -112,7 +112,8 @@ def create_timesheet(project, task, employee, activity, from_time, to_time):
             "project": project,
             "task": task,
             "from_time": from_time,
-            "to_time": to_time
+            "to_time": to_time,
+            "lag_time": lag_time
         })
         existing_timesheet.save()
         frappe.db.commit()
@@ -124,7 +125,8 @@ def create_timesheet(project, task, employee, activity, from_time, to_time):
             "project": project,
             "task": task,
             "from_time": from_time,
-            "to_time": to_time
+            "to_time": to_time,
+            "lag_time": lag_time
         })
 
         timesheet.insert(ignore_permissions=True)

--- a/one_compliance/setup.py
+++ b/one_compliance/setup.py
@@ -29,6 +29,7 @@ def create_custom_fields_for_app():
     create_custom_fields(get_terms_and_conditions_custom_fields())
     create_custom_fields(get_timesheet_custom_fields())
     create_custom_fields(get_todo_custom_fields())
+    create_custom_fields(get_timesheet_detail_custom_fields())
 
 
 def delete_custom_fields_for_app():
@@ -4869,6 +4870,12 @@ def get_project_template_task_custom_fields():
                 "unique": 0,
                 "width": None,
             },
+            {
+				"fieldname": "has_external_dependencies",
+				"fieldtype": "Check",
+				"label": "Has External Dependencies",
+				"insert_after": "custom_has_document"
+			}
         ]
     }
 
@@ -14305,3 +14312,20 @@ def get_todo_custom_fields():
             }
         ]
     }
+
+
+
+def get_timesheet_detail_custom_fields():
+    """
+    Returns custom fields for Timesheet Detail doctype.
+    """
+    return {
+		"Timesheet Detail": [
+			{
+				"fieldname": "lag_time",
+				"fieldtype": "Duration",
+				"label": "Lag Time",
+				"insert_after": "to_time"
+			}
+		]
+	}

--- a/one_compliance/setup.py
+++ b/one_compliance/setup.py
@@ -1,5 +1,6 @@
 import frappe
-from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from frappe.custom.doctype.custom_field.custom_field import \
+    create_custom_fields
 
 
 def after_migrate():
@@ -3995,7 +3996,7 @@ def get_project_template_custom_fields():
                 "columns": 0,
                 "creation": "2023-09-15 15:43:19.963650",
                 "default": None,
-                "depends_on": None,
+                "depends_on": "eval: doc.project_duration_type == 'Days'",
                 "description": None,
                 "docstatus": 0,
                 "dt": "Project Template",
@@ -4014,7 +4015,7 @@ def get_project_template_custom_fields():
                 "in_list_view": 0,
                 "in_preview": 0,
                 "in_standard_filter": 0,
-                "insert_after": "project_type",
+                "insert_after": "project_duration_type",
                 "is_system_generated": 0,
                 "is_virtual": 0,
                 "label": "Project Duration(Days)",
@@ -4490,7 +4491,23 @@ def get_project_template_custom_fields():
                 "fieldtype": "Button",
                 "label": "Add Tasks",
                 "insert_after": "premium_tasks"
-            }
+            },
+            {
+				"fieldname": "project_duration_type",
+				"fieldtype": "Select",
+				"label": "Project Duration Type",
+				"insert_after": "project_type",
+				"options": "\nDays\nMinutes"
+			},
+            {
+				"fieldname": "project_duration_minutes",
+				"fieldtype": "Duration",
+				"label": "Project Duration (Minutes)",
+				"insert_after": "project_duration_type",
+				"hide_days": 1,
+				"hide_seconds": 1,
+				"depends_on": "eval:doc.project_duration_type == 'Minutes' "
+			}
         ]
     }
 
@@ -4697,7 +4714,7 @@ def get_project_template_task_custom_fields():
                 "columns": 1,
                 "creation": "2023-10-05 16:55:57.256653",
                 "default": None,
-                "depends_on": None,
+                "depends_on": "eval:doc.task_duration_type == 'Days'",
                 "description": None,
                 "docstatus": 0,
                 "dt": "Project Template Task",
@@ -4716,7 +4733,7 @@ def get_project_template_task_custom_fields():
                 "in_list_view": 1,
                 "in_preview": 0,
                 "in_standard_filter": 0,
-                "insert_after": "subject",
+                "insert_after": "Task_duration_type",
                 "is_system_generated": 0,
                 "is_virtual": 0,
                 "label": "Task Duration",
@@ -4875,6 +4892,22 @@ def get_project_template_task_custom_fields():
 				"fieldtype": "Check",
 				"label": "Has External Dependencies",
 				"insert_after": "custom_has_document"
+			},
+             {
+				"fieldname": "Task_duration_type",
+				"fieldtype": "Select",
+				"label": "Task Duration Type",
+				"insert_after": "subject",
+				"options": "\nDays\nMinutes"
+			},
+            {
+				"fieldname": "task_duration_minutes",
+				"fieldtype": "Duration",
+				"label": "Task Duration (Minutes)",
+				"insert_after": "task_duration_type",
+				"hide_days": 1,
+				"hide_seconds": 1,
+				"depends_on": "eval:doc.task_duration_type == 'Minutes' "
 			}
         ]
     }


### PR DESCRIPTION
## Feature description

Add a checkbox in Project Template's "Tasks" Table
When stopping that task from Project Management Tool there must be an option to mark "Lag Time".
This Lag Time must be able to Approve by Management. (They must be able to  increase or decrease the "Lag time").


## Solution description
Created necessary fields to Lag Time from Task Management Tool .
Mapped details to timesheet when it is submitted

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d0452b45-c2f7-4cbc-8742-2fb393961946" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7e800c14-3426-4e91-b010-889ab6bbedd4" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/310ebed4-501b-48dc-84e3-0c6b2ebd040a" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/74efee03-eae6-4c25-a955-1712679a73a8" />



## Was this feature tested on the browsers?
  - Chrome

