### PR TITLE
feat: track lag_time of task and mark project duration type

### DIFF
--- a/one_compliance/custom/custom_field/project_template.py
+++ b/one_compliance/custom/custom_field/project_template.py
@@ -20,8 +20,9 @@ def get_project_template_custom_fields():
 			{
 				"fieldname": "custom_project_duration",
 				"fieldtype": "Int",
-				"insert_after": "project_type",
+				"insert_after": "project_duration_type",
 				"label": "Project Duration(Days)",
+				"depends_on": "eval: doc.project_duration_type == 'Days'"
 			},
 			{
 				"fetch_from": "compliance_sub_category.category_type",
@@ -81,5 +82,21 @@ def get_project_template_custom_fields():
 				"label": "Add Tasks",
 				"insert_after": "premium_tasks",
 			},
+			{
+				"fieldname": "project_duration_type",
+				"fieldtype": "Select",
+				"label": "Project Duration Type",
+				"insert_after": "project_type",
+				"options": "\nDays\nMinutes"
+			},
+            {
+				"fieldname": "project_duration_minutes",
+				"fieldtype": "Duration",
+				"label": "Project Duration (Minutes)",
+				"insert_after": "project_duration_type",
+				"hide_days": 1,
+				"hide_seconds": 1,
+				"depends_on": "eval:doc.project_duration_type == 'Minutes' "
+			}
 		]
 	}

--- a/one_compliance/custom/custom_field/project_template_task.py
+++ b/one_compliance/custom/custom_field/project_template_task.py
@@ -58,6 +58,28 @@ def get_project_template_task_custom_fields():
 				"options": "\n0\n1\n2\n3\n4\n5\n",
 				"insert_after": "custom_task_duration",
 				"in_list_view": 1
+			},
+			{
+				"fieldname": "has_external_dependencies",
+				"fieldtype": "Check",
+				"label": "Has External Dependencies",
+				"insert_after": "custom_has_document"
+			},
+             {
+				"fieldname": "Task_duration_type",
+				"fieldtype": "Select",
+				"label": "Task Duration Type",
+				"insert_after": "subject",
+				"options": "\nDays\nMinutes"
+			},
+            {
+				"fieldname": "task_duration_minutes",
+				"fieldtype": "Duration",
+				"label": "Task Duration (Minutes)",
+				"insert_after": "task_duration_type",
+				"hide_days": 1,
+				"hide_seconds": 1,
+				"depends_on": "eval:doc.task_duration_type == 'Minutes' "
 			}
 		]
 	}

--- a/one_compliance/custom/custom_field/timesheet_detail.py
+++ b/one_compliance/custom/custom_field/timesheet_detail.py
@@ -1,0 +1,14 @@
+def get_timesheet_detail_custom_fields():
+    """
+    Returns custom fields for Timesheet Detail doctype.
+    """
+    return {
+		"Timesheet Detail": [
+			{
+				"fieldname": "lag_time",
+				"fieldtype": "Duration",
+				"label": "Lag Time",
+				"insert_after": "to_time"
+			}
+		]
+	}

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
@@ -658,41 +658,47 @@ function showTimeEntryDialog(page, taskName, projectName, assignees, startTime) 
                 fieldname: "project",
                 fieldtype: 'Link',
                 options: 'Project',
-								default: projectName
+				default: projectName
             },
             {
                 label: __("From Time"),
                 fieldname: "from_time",
                 fieldtype: 'Datetime',
                 reqd: true,
-								read_only: 1,
-								default: fromTime,
+				read_only: 1,
+				default: fromTime,
             },
-						{
-							fieldtype: "Column Break",
-							fieldname: "col_break_1",
-						},
-						{
+			{
+				fieldtype: "Column Break",
+				fieldname: "col_break_1",
+			},
+			{
                 label: __("Task"),
                 fieldname: "task",
                 fieldtype: 'Link',
                 options: 'Task',
-								default: taskName
+				default: taskName
             },
 						{
                 label: __("Activity"),
                 fieldname: "activity",
                 fieldtype: 'Link',
                 reqd: true,
-								options: 'Activity Type'
+				options: 'Activity Type'
             },
             {
                 label: __("To Time"),
                 fieldname: "to_time",
                 fieldtype: 'Datetime',
                 reqd: true,
-								read_only: 1,
-								default: toTime
+				read_only: 1,
+				default: toTime
+            },
+            {
+                label: __("Lag Time"),
+                fieldname: "lag_time",
+                fieldtype: 'Duration',
+
             }
         ],
         primary_action: function (values) {
@@ -707,7 +713,8 @@ function showTimeEntryDialog(page, taskName, projectName, assignees, startTime) 
 										employee: values.employee,
 										activity: values.activity,
 										from_time: values.from_time,
-										to_time: values.to_time
+										to_time: values.to_time,
+                                        lag_time: values.lag_time,
 								},
 								callback: function (r) {
 										frappe.msgprint("Timesheet created successfully!");

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 from frappe.utils import get_datetime
 from erpnext.accounts.party import get_party_account
 
@@ -92,7 +93,7 @@ def get_task(status = None, task = None, project = None, customer = None, depart
     return task_list
 
 @frappe.whitelist()
-def create_timesheet(project, task, employee, activity, from_time, to_time):
+def create_timesheet(project, task, employee, activity, from_time, to_time, lag_time=None):
 
     from_time = get_datetime(from_time)
     to_time = get_datetime(to_time)
@@ -112,7 +113,8 @@ def create_timesheet(project, task, employee, activity, from_time, to_time):
             "project": project,
             "task": task,
             "from_time": from_time,
-            "to_time": to_time
+            "to_time": to_time,
+            "lag_time": lag_time
         })
         existing_timesheet.save()
         frappe.db.commit()
@@ -124,7 +126,8 @@ def create_timesheet(project, task, employee, activity, from_time, to_time):
             "project": project,
             "task": task,
             "from_time": from_time,
-            "to_time": to_time
+            "to_time": to_time,
+            "lag_time": lag_time
         })
 
         timesheet.insert(ignore_permissions=True)
@@ -154,11 +157,6 @@ def add_payment_info(task_id, payable_amount, mode_of_payment, reference_number=
     payment_info['journal_entry'] = journal_entry
     task_doc.append("custom_task_payment_informations", payment_info)
     task_doc.custom_is_payable = 1
-    # task_doc.custom_payable_amount = payable_amount
-    # task_doc.custom_mode_of_payment = mode_of_payment
-    # task_doc.custom_reference_number = reference_number
-    # task_doc.custom_reference_date = reference_date
-    # task_doc.custom_user_remark = user_remark
     task_doc.save()
     task_doc.reload()
     sales_order = frappe.db.get_value("Project", task_doc.project, 'sales_order') or None

--- a/one_compliance/setup.py
+++ b/one_compliance/setup.py
@@ -19,6 +19,7 @@ from one_compliance.custom.custom_field.terms_and_conditions import get_terms_an
 from one_compliance.custom.custom_field.timesheet import get_timesheet_custom_fields
 from one_compliance.custom.custom_field.todo import get_todo_custom_fields
 from one_compliance.custom.custom_field.opportunity_item import get_opportunity_item_custom_fields
+from one_compliance.custom.custom_field.timesheet_detail import get_timesheet_detail_custom_fields
 
 # Custom property setter method imports
 from one_compliance.custom.property_setter.contact_email import get_contact_email_property_setters


### PR DESCRIPTION
## Feature description

Add a checkbox in Project Template's "Tasks" Table
When stopping that task from Project Management Tool there must be an option to mark "Lag Time".
This Lag Time must be able to Approve by Management. (They must be able to increase or decrease the "Lag time").


## Solution description

Created necessary fields to Lag Time from Task Management Tool .
Mapped details to timesheet when it is submitted

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/58f380c1-9fa5-4095-8afa-ee8cf811def5" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4de06bea-81db-4b45-a77c-2f7b6b4151e8" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/31ae2d54-12b7-42a1-b50a-c97d2434839f" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cb9c578d-fabb-404b-8293-6a94534c8082" />


## Was this feature tested on the browsers?
  - Chrome

