### PR TITLE
create opportunity from sales order

### DIFF
--- a/one_compliance/custom/custom_field/opportunity.py
+++ b/one_compliance/custom/custom_field/opportunity.py
@@ -40,7 +40,7 @@ def get_opportunity_custom_fields():
 				"fieldname": "follow_up_reply",
 				"fieldtype": "Small Text",
 				"label": "Follow up Reply",			
-				"insert_after": "notes_html"
+				"insert_after": "open_activities_html"
 			}
 		]
 	}

--- a/one_compliance/custom/custom_field/opportunity.py
+++ b/one_compliance/custom/custom_field/opportunity.py
@@ -16,5 +16,18 @@ def get_opportunity_custom_fields():
 				"fieldtype": "Section Break",
 				"insert_after": "total",
 			},
+			{
+                "fieldname": "sales_order",
+                "fieldtype": "Link",
+                "label": "Sales Order",
+                "insert_after": "annual_revenue",
+                "options": "Sales Order"
+            },
+            {
+				"fieldname": "follow_up_reply",
+				"fieldtype": "Small Text",
+				"label": "Follow up Reply",			
+				"insert_after": "notes_html"
+			}
 		]
 	}

--- a/one_compliance/custom/custom_field/opportunity.py
+++ b/one_compliance/custom/custom_field/opportunity.py
@@ -17,13 +17,26 @@ def get_opportunity_custom_fields():
 				"insert_after": "total",
 			},
 			{
-                "fieldname": "sales_order",
-                "fieldtype": "Link",
-                "label": "Sales Order",
-                "insert_after": "annual_revenue",
-                "options": "Sales Order"
-            },
-            {
+				"fieldname": "sales_order",
+				"fieldtype": "Link",
+				"label": "Sales Order",
+				"insert_after": "annual_revenue",
+				"options": "Sales Order"
+			},
+			{
+				"fieldname": "opportunity_date",
+				"fieldtype": "Date",
+				"label": "Opportunity Date",
+				"insert_after": "sales_order",
+				"default": "Today"
+			},
+			{
+				"fieldname": "notes_html",
+				"fieldtype": "HTML",
+				"label": "Notes",			
+				"insert_after": "custom_documents_required"
+			},
+			{
 				"fieldname": "follow_up_reply",
 				"fieldtype": "Small Text",
 				"label": "Follow up Reply",			

--- a/one_compliance/custom/custom_field/opportunity_item.py
+++ b/one_compliance/custom/custom_field/opportunity_item.py
@@ -1,0 +1,24 @@
+def get_opportunity_item_custom_fields():
+	'''
+		Method to get custom fields for Opportunity Item doctype
+	'''
+	return {
+		"Opportunity Item": [
+			{
+				"fieldname": "compliance_category",
+				"label": "Compliance Category",
+				"fieldtype": "Link",
+				"options": "Compliance Category",
+				"insert_after": "item_code",
+				"in_list_view": 1,
+			},
+			{
+				"fieldname": "compliance_sub_category",
+				"label": "Compliance Sub Category",
+				"fieldtype": "Link",				
+				"options": "Compliance Sub Category",		
+				"insert_after": "compliance_category",
+				"in_list_view": 1,	
+			}
+		]
+}

--- a/one_compliance/custom/custom_field/sales_order.py
+++ b/one_compliance/custom/custom_field/sales_order.py
@@ -138,6 +138,12 @@ def get_sales_order_custom_fields():
                 "fieldtype": "Check",
                 "label": "Follow up for next Project",
                 "insert_after": "custom_create_project_automatically"
-            }
+            },
+			{
+				"fieldname": "follow_up_completed",
+				"fieldtype": "Check",
+				"label": "Follow up Completed",
+				"insert_after": "follow_up_for_next_project"
+			}
 		]
 	}

--- a/one_compliance/custom/custom_field/sales_order.py
+++ b/one_compliance/custom/custom_field/sales_order.py
@@ -133,5 +133,11 @@ def get_sales_order_custom_fields():
 				"options": "Event",
 				"read_only": 1,
 			},
+			{
+                "fieldname": "follow_up_for_next_project",
+                "fieldtype": "Check",
+                "label": "Follow up for next Project",
+                "insert_after": "custom_create_project_automatically"
+            }
 		]
 	}

--- a/one_compliance/custom/custom_field/sales_order.py
+++ b/one_compliance/custom/custom_field/sales_order.py
@@ -143,7 +143,8 @@ def get_sales_order_custom_fields():
 				"fieldname": "follow_up_completed",
 				"fieldtype": "Check",
 				"label": "Follow up Completed",
-				"insert_after": "follow_up_for_next_project"
+				"insert_after": "follow_up_for_next_project",
+				"hidden": 1
 			}
 		]
 	}

--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -166,6 +166,7 @@ doc_events = {
         'on_submit':'one_compliance.one_compliance.doc_events.sales_order.create_project_on_submit',
         'on_cancel': 'one_compliance.one_compliance.doc_events.sales_order.so_on_cancel_custom',
         'on_update_after_submit': 'one_compliance.one_compliance.doc_events.sales_order.so_on_update_after_submit',
+        'validate': 'one_compliance.one_compliance.doc_events.sales_order.set_compliance_fields'
     },
     'Payment Entry':{
         'on_submit': 'one_compliance.one_compliance.doc_events.payment_entry.payment_entry_on_submit'

--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -195,7 +195,8 @@ scheduler_events = {
         'one_compliance.one_compliance.utils.notification_for_digital_signature_expiry',
         'one_compliance.one_compliance.utils.project_overdue_notification',
         'one_compliance.one_compliance.doc_events.project.set_status_to_overdue',
-        'one_compliance.one_compliance.doctype.compliance_sub_category.compliance_sub_category.send_repeat_notif'
+        'one_compliance.one_compliance.doctype.compliance_sub_category.compliance_sub_category.send_repeat_notif',
+        'one_compliance.one_compliance.doc_events.sales_order.create_opportunity'
     ],
 #	"hourly": [
 #		"one_compliance.tasks.hourly"

--- a/one_compliance/one_compliance/doc_events/oppotunity.py
+++ b/one_compliance/one_compliance/doc_events/oppotunity.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.model.mapper import *
 from frappe import _
+from frappe.utils import getdate, today, get_link_to_form
 
 @frappe.whitelist()
 def make_engagement_letter(source_name,target_name=None):
@@ -48,3 +49,45 @@ def set_opportunity_converted(doc, method):
 
 	if opportunity_name:
 		frappe.db.set_value('Opportunity', opportunity_name, 'status', 'Converted')
+
+
+@frappe.whitelist()
+def create_sales_order(opportunity):
+    if not frappe.db.exists('Opportunity', opportunity):
+        frappe.throw("Opportunity not found")
+
+    opp = frappe.get_doc('Opportunity', opportunity)
+    customer = create_if_customer_not_exists(opp)
+
+    items = []
+    for i in opp.items:
+        items.append({
+            "item_code": i.item_code,
+            "item_name": i.item_name,
+            "uom": i.uom,
+            "qty": i.qty,
+            "rate": i.rate,
+            "custom_compliance_category": i.compliance_category,
+			"custom_compliance_subcategory": i.compliance_sub_category,
+        })
+
+    return {
+        "customer": customer,
+        "items": items
+    }
+
+def create_if_customer_not_exists(opp):
+    if opp.opportunity_from == 'Customer':
+        return opp.party_name
+
+    existing = frappe.db.get_value('Customer', {'opportunity_name': opp.name})
+    if existing:
+        return existing
+
+    customer = frappe.new_doc('Customer')
+    customer.opportunity_name = opp.name
+    customer.customer_name = opp.contact_person or "Unnamed Customer"
+    customer.compliance_customer_type = opp.custom_customer_type or frappe.db.get_single_value("Compliance Settings", "customer_type")
+    customer.flags.ignore_mandatory = True
+    customer.save(ignore_permissions=True)
+    return customer.name

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import frappe
 from frappe import _
@@ -316,6 +316,169 @@ def delete_linked_records(sales_order):
 
 
 
+# @frappe.whitelist()
+# def create_opportunity():
+# 	"""
+# 	Creates Opportunities for Sales Orders flagged for follow_up_for_next_project
+# 	and assigns a Task to follow_up_person from Compliance Sub Category
+# 	"""
+# 	today_date = getdate(today())
+# 	this_year = today_date.year
+# 	this_month = today_date.month
+
+# 	print(f"[INFO] Today's Date: {today_date}")
+
+# 	# Get all eligible Sales Orders
+# 	sales_orders = frappe.db.get_all(
+# 		"Sales Order",
+# 		filters={"follow_up_for_next_project": 1, "follow_up_completed": 0},
+# 		fields=["name", "customer", "status", "workflow_state", "company", "follow_up_completed"]
+# 	)
+
+# 	for so in sales_orders:
+# 		# Fetch Sales Order Items with compliance fields
+# 		sales_order_items = frappe.get_all(
+# 			"Sales Order Item",
+# 			filters={"parent": so.name},
+# 			fields=[
+# 				"item_code", "item_name", "uom", "qty",
+# 				"brand", "item_group", "description",
+# 				"image", "base_rate", "base_amount", "rate", "amount",
+# 				"custom_compliance_subcategory as compliance_sub_category",
+# 				"custom_compliance_category as compliance_category"
+# 			]
+# 		)
+
+# 		for item in sales_order_items:
+# 			subcat_name = item.compliance_sub_category
+# 			if not subcat_name:
+# 				continue
+
+# 			compliance = frappe.get_doc("Compliance Sub Category", subcat_name)
+
+# 			# Only if repeat + notifications allowed
+# 			if not (compliance.allow_repeat and compliance.renew_notif):
+# 				continue
+
+# 			day = int(compliance.day or 1)
+# 			notif_days = int(float(compliance.renew_notif_days_before or 0))
+# 			repeat_on = compliance.repeat_on
+# 			scheduled_date = None
+
+# 			try:
+# 				if repeat_on == "Monthly":
+# 					scheduled_date = datetime(this_year, this_month, day).date()
+# 					print(this_year, this_month, day, datetime(this_year, this_month, day).date())
+
+# 				elif repeat_on == "Quarterly":
+# 					for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
+# 						d = datetime(this_year, m, day).date()
+# 						if d >= today_date:
+# 							scheduled_date = d
+# 							break
+
+# 				elif repeat_on == "Half Yearly":
+# 					for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
+# 						d = datetime(this_year, m, day).date()
+# 						if d >= today_date:
+# 							scheduled_date = d
+# 							break
+
+# 				elif repeat_on == "Yearly":
+# 					if compliance.month:
+# 						m = datetime.strptime(compliance.month, "%B").month
+# 						scheduled_date = datetime(this_year, m, day).date()
+
+# 			except Exception as e:
+# 				print(f"[WARN] Skipping {subcat_name}: Invalid date - {e}")
+# 				continue
+
+# 			if not scheduled_date:
+# 				continue
+
+# 			notif_trigger_date = add_days(scheduled_date, -notif_days)
+# 			print(add_days(scheduled_date, -notif_days),"-->>", scheduled_date, "->", notif_days, "->", -notif_days)
+# 			print(f"[DEBUG] For {subcat_name}: Scheduled on {scheduled_date}, Notify on {notif_trigger_date}")
+
+# 			if notif_trigger_date != today_date:
+# 				continue
+
+# 			# Skip if Opportunity already exists
+# 			existing_opportunity = frappe.db.exists("Opportunity", {"sales_order": so.name})
+# 			if existing_opportunity:
+# 				print(f"[SKIP] Opportunity already exists for Opportunity Date : {today_date}")
+# 				continue
+
+# 			try:
+# 				# Only create for active sales orders
+# 				if so.status not in ["Draft", "Closed", "Cancelled"] or so.workflow_state not in ["Pending", "Cancelled"]:
+# 					opportunity = frappe.new_doc("Opportunity")
+# 					opportunity.opportunity_from = "Customer"
+# 					opportunity.party_name = so.customer
+# 					opportunity.status = "Open"
+# 					opportunity.opportunity_type = "Sales"
+# 					opportunity.sales_order = so.name
+# 					opportunity.naming_series = "CRM-OPP-.YYYY.-"
+# 					opportunity.company = so.company
+# 					opportunity.opportunity_date = today_date
+
+# 					# Map Sales Order Items → Opportunity Items
+# 					for soi in sales_order_items:
+# 						opp_item = opportunity.append("items", {})
+# 						opp_item.item_code = soi.item_code
+# 						opp_item.item_name = soi.item_name
+# 						opp_item.uom = soi.uom
+# 						opp_item.qty = soi.qty
+# 						opp_item.brand = soi.brand
+# 						opp_item.item_group = soi.item_group
+# 						opp_item.description = soi.description
+# 						opp_item.image = soi.image
+# 						opp_item.base_rate = soi.base_rate
+# 						opp_item.base_amount = soi.base_amount
+# 						opp_item.rate = soi.rate
+# 						opp_item.amount = soi.amount
+
+# 						# Map compliance fields to Opportunity Item
+# 						opp_item.compliance_category = soi.compliance_category
+# 						opp_item.compliance_sub_category = soi.compliance_sub_category
+
+# 					opportunity.insert(ignore_permissions=True)
+# 					frappe.db.commit()
+	 
+# 					frappe.db.set_value("Sales Order", so.name, "follow_up_completed", 1)
+# 					frappe.db.commit()
+
+# 					print(f"[SUCCESS] Created Opportunity: {opportunity.name} for {subcat_name}")
+
+# 					# Create and assign Task
+# 					follow_up_user = frappe.db.get_value("Employee", compliance.follow_up_person, "user_id")
+
+# 					try:
+
+# 						if follow_up_user:
+# 							todo = frappe.new_doc("ToDo")
+# 							todo.owner = follow_up_user
+# 							todo.assigned_by = frappe.session.user
+# 							todo.allocated_to = follow_up_user
+# 							todo.reference_type = "Opportunity"
+# 							todo.reference_name = opportunity.name
+# 							todo.description = f"Follow up for compliance sub category: {subcat_name}"
+# 							todo.status = "Open"
+# 							todo.priority = "Medium"
+# 							todo.date = today()
+# 							todo.insert(ignore_permissions=True)
+# 							frappe.db.commit()
+
+# 						print(f"[SUCCESS] Created and assigned Todo {todo.name} to {follow_up_user}")
+
+# 					except Exception as e:
+# 						print(f"[ERROR] Failed to create Todo for {subcat_name}: {e}")
+
+# 			except Exception as e:
+# 				print(f"[ERROR] Failed to create opportunity for {subcat_name}: {e}")
+
+
+
 @frappe.whitelist()
 def create_opportunity():
 	"""
@@ -328,7 +491,7 @@ def create_opportunity():
 
 	print(f"[INFO] Today's Date: {today_date}")
 
-	# Get all eligible Sales Orders
+
 	sales_orders = frappe.db.get_all(
 		"Sales Order",
 		filters={"follow_up_for_next_project": 1, "follow_up_completed": 0},
@@ -336,7 +499,6 @@ def create_opportunity():
 	)
 
 	for so in sales_orders:
-		# Fetch Sales Order Items with compliance fields
 		sales_order_items = frappe.get_all(
 			"Sales Order Item",
 			filters={"parent": so.name},
@@ -356,7 +518,7 @@ def create_opportunity():
 
 			compliance = frappe.get_doc("Compliance Sub Category", subcat_name)
 
-			# Only if repeat + notifications allowed
+
 			if not (compliance.allow_repeat and compliance.renew_notif):
 				continue
 
@@ -366,27 +528,49 @@ def create_opportunity():
 			scheduled_date = None
 
 			try:
+				# ---------------- Monthly ----------------
 				if repeat_on == "Monthly":
-					scheduled_date = datetime(this_year, this_month, day).date()
+					# Calculate last day of current month
+					last_day_of_month = (datetime(this_year, this_month + 1, 1) - timedelta(days=1)).day \
+						if this_month < 12 else 31
 
+					# If today is last day of month & compliance day = 1 -> next month
+					if day == 1 and today_date.day == last_day_of_month:
+						next_month = this_month + 1 if this_month < 12 else 1
+						next_year = this_year if this_month < 12 else this_year + 1
+						scheduled_date = datetime(next_year, next_month, 1).date()
+					else:
+						scheduled_date = datetime(this_year, this_month, day).date()
+
+				# ---------------- Quarterly ----------------
 				elif repeat_on == "Quarterly":
-					for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
+					for m in [1, 4, 7, 10]:
 						d = datetime(this_year, m, day).date()
 						if d >= today_date:
 							scheduled_date = d
 							break
+					if not scheduled_date:
+						scheduled_date = datetime(this_year + 1, 1, day).date()
 
+				# ---------------- Half Yearly ----------------
 				elif repeat_on == "Half Yearly":
-					for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
+					for m in [1, 7]:
 						d = datetime(this_year, m, day).date()
 						if d >= today_date:
 							scheduled_date = d
 							break
+					if not scheduled_date:
+						scheduled_date = datetime(this_year + 1, 1, day).date()
 
+				# ---------------- Yearly ----------------
 				elif repeat_on == "Yearly":
 					if compliance.month:
 						m = datetime.strptime(compliance.month, "%B").month
-						scheduled_date = datetime(this_year, m, day).date()
+						d = datetime(this_year, m, day).date()
+						if d >= today_date:
+							scheduled_date = d
+						else:
+							scheduled_date = datetime(this_year + 1, m, day).date()
 
 			except Exception as e:
 				print(f"[WARN] Skipping {subcat_name}: Invalid date - {e}")
@@ -395,7 +579,15 @@ def create_opportunity():
 			if not scheduled_date:
 				continue
 
-			notif_trigger_date = add_days(scheduled_date, -notif_days)
+			# --- Notification trigger date ---
+			if day == 1 and notif_days > 0:
+				prev_month = scheduled_date.month - 1 if scheduled_date.month > 1 else 12
+				prev_year = scheduled_date.year if scheduled_date.month > 1 else scheduled_date.year - 1
+				last_day_prev_month = (datetime(prev_year, prev_month + 1, 1) - timedelta(days=1)).date()
+				notif_trigger_date = last_day_prev_month
+			else:
+				notif_trigger_date = add_days(scheduled_date, -notif_days)
+
 			print(f"[DEBUG] For {subcat_name}: Scheduled on {scheduled_date}, Notify on {notif_trigger_date}")
 
 			if notif_trigger_date != today_date:
@@ -442,7 +634,7 @@ def create_opportunity():
 
 					opportunity.insert(ignore_permissions=True)
 					frappe.db.commit()
-     
+	 
 					frappe.db.set_value("Sales Order", so.name, "follow_up_completed", 1)
 					frappe.db.commit()
 
@@ -452,7 +644,6 @@ def create_opportunity():
 					follow_up_user = frappe.db.get_value("Employee", compliance.follow_up_person, "user_id")
 
 					try:
-
 						if follow_up_user:
 							todo = frappe.new_doc("ToDo")
 							todo.owner = follow_up_user
@@ -467,7 +658,7 @@ def create_opportunity():
 							todo.insert(ignore_permissions=True)
 							frappe.db.commit()
 
-						print(f"[SUCCESS] Created and assigned Todo {todo.name} to {follow_up_user}")
+							print(f"[SUCCESS] Created and assigned Todo {todo.name} to {follow_up_user}")
 
 					except Exception as e:
 						print(f"[ERROR] Failed to create Todo for {subcat_name}: {e}")

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -315,170 +315,6 @@ def delete_linked_records(sales_order):
 	return "success"
 
 
-
-# @frappe.whitelist()
-# def create_opportunity():
-# 	"""
-# 	Creates Opportunities for Sales Orders flagged for follow_up_for_next_project
-# 	and assigns a Task to follow_up_person from Compliance Sub Category
-# 	"""
-# 	today_date = getdate(today())
-# 	this_year = today_date.year
-# 	this_month = today_date.month
-
-# 	print(f"[INFO] Today's Date: {today_date}")
-
-# 	# Get all eligible Sales Orders
-# 	sales_orders = frappe.db.get_all(
-# 		"Sales Order",
-# 		filters={"follow_up_for_next_project": 1, "follow_up_completed": 0},
-# 		fields=["name", "customer", "status", "workflow_state", "company", "follow_up_completed"]
-# 	)
-
-# 	for so in sales_orders:
-# 		# Fetch Sales Order Items with compliance fields
-# 		sales_order_items = frappe.get_all(
-# 			"Sales Order Item",
-# 			filters={"parent": so.name},
-# 			fields=[
-# 				"item_code", "item_name", "uom", "qty",
-# 				"brand", "item_group", "description",
-# 				"image", "base_rate", "base_amount", "rate", "amount",
-# 				"custom_compliance_subcategory as compliance_sub_category",
-# 				"custom_compliance_category as compliance_category"
-# 			]
-# 		)
-
-# 		for item in sales_order_items:
-# 			subcat_name = item.compliance_sub_category
-# 			if not subcat_name:
-# 				continue
-
-# 			compliance = frappe.get_doc("Compliance Sub Category", subcat_name)
-
-# 			# Only if repeat + notifications allowed
-# 			if not (compliance.allow_repeat and compliance.renew_notif):
-# 				continue
-
-# 			day = int(compliance.day or 1)
-# 			notif_days = int(float(compliance.renew_notif_days_before or 0))
-# 			repeat_on = compliance.repeat_on
-# 			scheduled_date = None
-
-# 			try:
-# 				if repeat_on == "Monthly":
-# 					scheduled_date = datetime(this_year, this_month, day).date()
-# 					print(this_year, this_month, day, datetime(this_year, this_month, day).date())
-
-# 				elif repeat_on == "Quarterly":
-# 					for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
-# 						d = datetime(this_year, m, day).date()
-# 						if d >= today_date:
-# 							scheduled_date = d
-# 							break
-
-# 				elif repeat_on == "Half Yearly":
-# 					for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
-# 						d = datetime(this_year, m, day).date()
-# 						if d >= today_date:
-# 							scheduled_date = d
-# 							break
-
-# 				elif repeat_on == "Yearly":
-# 					if compliance.month:
-# 						m = datetime.strptime(compliance.month, "%B").month
-# 						scheduled_date = datetime(this_year, m, day).date()
-
-# 			except Exception as e:
-# 				print(f"[WARN] Skipping {subcat_name}: Invalid date - {e}")
-# 				continue
-
-# 			if not scheduled_date:
-# 				continue
-
-# 			notif_trigger_date = add_days(scheduled_date, -notif_days)
-# 			print(add_days(scheduled_date, -notif_days),"-->>", scheduled_date, "->", notif_days, "->", -notif_days)
-# 			print(f"[DEBUG] For {subcat_name}: Scheduled on {scheduled_date}, Notify on {notif_trigger_date}")
-
-# 			if notif_trigger_date != today_date:
-# 				continue
-
-# 			# Skip if Opportunity already exists
-# 			existing_opportunity = frappe.db.exists("Opportunity", {"sales_order": so.name})
-# 			if existing_opportunity:
-# 				print(f"[SKIP] Opportunity already exists for Opportunity Date : {today_date}")
-# 				continue
-
-# 			try:
-# 				# Only create for active sales orders
-# 				if so.status not in ["Draft", "Closed", "Cancelled"] or so.workflow_state not in ["Pending", "Cancelled"]:
-# 					opportunity = frappe.new_doc("Opportunity")
-# 					opportunity.opportunity_from = "Customer"
-# 					opportunity.party_name = so.customer
-# 					opportunity.status = "Open"
-# 					opportunity.opportunity_type = "Sales"
-# 					opportunity.sales_order = so.name
-# 					opportunity.naming_series = "CRM-OPP-.YYYY.-"
-# 					opportunity.company = so.company
-# 					opportunity.opportunity_date = today_date
-
-# 					# Map Sales Order Items → Opportunity Items
-# 					for soi in sales_order_items:
-# 						opp_item = opportunity.append("items", {})
-# 						opp_item.item_code = soi.item_code
-# 						opp_item.item_name = soi.item_name
-# 						opp_item.uom = soi.uom
-# 						opp_item.qty = soi.qty
-# 						opp_item.brand = soi.brand
-# 						opp_item.item_group = soi.item_group
-# 						opp_item.description = soi.description
-# 						opp_item.image = soi.image
-# 						opp_item.base_rate = soi.base_rate
-# 						opp_item.base_amount = soi.base_amount
-# 						opp_item.rate = soi.rate
-# 						opp_item.amount = soi.amount
-
-# 						# Map compliance fields to Opportunity Item
-# 						opp_item.compliance_category = soi.compliance_category
-# 						opp_item.compliance_sub_category = soi.compliance_sub_category
-
-# 					opportunity.insert(ignore_permissions=True)
-# 					frappe.db.commit()
-	 
-# 					frappe.db.set_value("Sales Order", so.name, "follow_up_completed", 1)
-# 					frappe.db.commit()
-
-# 					print(f"[SUCCESS] Created Opportunity: {opportunity.name} for {subcat_name}")
-
-# 					# Create and assign Task
-# 					follow_up_user = frappe.db.get_value("Employee", compliance.follow_up_person, "user_id")
-
-# 					try:
-
-# 						if follow_up_user:
-# 							todo = frappe.new_doc("ToDo")
-# 							todo.owner = follow_up_user
-# 							todo.assigned_by = frappe.session.user
-# 							todo.allocated_to = follow_up_user
-# 							todo.reference_type = "Opportunity"
-# 							todo.reference_name = opportunity.name
-# 							todo.description = f"Follow up for compliance sub category: {subcat_name}"
-# 							todo.status = "Open"
-# 							todo.priority = "Medium"
-# 							todo.date = today()
-# 							todo.insert(ignore_permissions=True)
-# 							frappe.db.commit()
-
-# 						print(f"[SUCCESS] Created and assigned Todo {todo.name} to {follow_up_user}")
-
-# 					except Exception as e:
-# 						print(f"[ERROR] Failed to create Todo for {subcat_name}: {e}")
-
-# 			except Exception as e:
-# 				print(f"[ERROR] Failed to create opportunity for {subcat_name}: {e}")
-
-
-
 @frappe.whitelist()
 def create_opportunity():
 	"""
@@ -488,9 +324,6 @@ def create_opportunity():
 	today_date = getdate(today())
 	this_year = today_date.year
 	this_month = today_date.month
-
-	print(f"[INFO] Today's Date: {today_date}")
-
 
 	sales_orders = frappe.db.get_all(
 		"Sales Order",
@@ -518,7 +351,6 @@ def create_opportunity():
 
 			compliance = frappe.get_doc("Compliance Sub Category", subcat_name)
 
-
 			if not (compliance.allow_repeat and compliance.renew_notif):
 				continue
 
@@ -530,11 +362,9 @@ def create_opportunity():
 			try:
 				# ---------------- Monthly ----------------
 				if repeat_on == "Monthly":
-					# Calculate last day of current month
 					last_day_of_month = (datetime(this_year, this_month + 1, 1) - timedelta(days=1)).day \
 						if this_month < 12 else 31
 
-					# If today is last day of month & compliance day = 1 -> next month
 					if day == 1 and today_date.day == last_day_of_month:
 						next_month = this_month + 1 if this_month < 12 else 1
 						next_year = this_year if this_month < 12 else this_year + 1
@@ -573,7 +403,7 @@ def create_opportunity():
 							scheduled_date = datetime(this_year + 1, m, day).date()
 
 			except Exception as e:
-				print(f"[WARN] Skipping {subcat_name}: Invalid date - {e}")
+				frappe.log_error(f"Invalid date calculation for {subcat_name}: {e}", "Create Opportunity Error")
 				continue
 
 			if not scheduled_date:
@@ -588,15 +418,12 @@ def create_opportunity():
 			else:
 				notif_trigger_date = add_days(scheduled_date, -notif_days)
 
-			print(f"[DEBUG] For {subcat_name}: Scheduled on {scheduled_date}, Notify on {notif_trigger_date}")
-
 			if notif_trigger_date != today_date:
 				continue
 
 			# Skip if Opportunity already exists
 			existing_opportunity = frappe.db.exists("Opportunity", {"sales_order": so.name})
 			if existing_opportunity:
-				print(f"[SKIP] Opportunity already exists for Opportunity Date : {today_date}")
 				continue
 
 			try:
@@ -612,7 +439,6 @@ def create_opportunity():
 					opportunity.company = so.company
 					opportunity.opportunity_date = today_date
 
-					# Map Sales Order Items → Opportunity Items
 					for soi in sales_order_items:
 						opp_item = opportunity.append("items", {})
 						opp_item.item_code = soi.item_code
@@ -627,8 +453,6 @@ def create_opportunity():
 						opp_item.base_amount = soi.base_amount
 						opp_item.rate = soi.rate
 						opp_item.amount = soi.amount
-
-						# Map compliance fields to Opportunity Item
 						opp_item.compliance_category = soi.compliance_category
 						opp_item.compliance_sub_category = soi.compliance_sub_category
 
@@ -638,9 +462,6 @@ def create_opportunity():
 					frappe.db.set_value("Sales Order", so.name, "follow_up_completed", 1)
 					frappe.db.commit()
 
-					print(f"[SUCCESS] Created Opportunity: {opportunity.name} for {subcat_name}")
-
-					# Create and assign Task
 					follow_up_user = frappe.db.get_value("Employee", compliance.follow_up_person, "user_id")
 
 					try:
@@ -658,13 +479,12 @@ def create_opportunity():
 							todo.insert(ignore_permissions=True)
 							frappe.db.commit()
 
-							print(f"[SUCCESS] Created and assigned Todo {todo.name} to {follow_up_user}")
-
 					except Exception as e:
-						print(f"[ERROR] Failed to create Todo for {subcat_name}: {e}")
+						frappe.log_error(f"Failed to create ToDo for {subcat_name}: {e}", "Create Opportunity Error")
 
 			except Exception as e:
-				print(f"[ERROR] Failed to create opportunity for {subcat_name}: {e}")
+				frappe.log_error(f"Failed to create Opportunity for {subcat_name}: {e}", "Create Opportunity Error")
+
 
 
 def set_compliance_fields(doc, method):

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -4,6 +4,8 @@ from frappe.utils import add_days, add_months, date_diff, getdate, json, today
 from one_compliance.one_compliance.utils import add_custom as add_assign
 from one_compliance.one_compliance.utils import create_todo, get_users_with_role
 
+from datetime import datetime
+
 
 @frappe.whitelist()
 def update_journal_entry(doc):

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -311,3 +311,189 @@ def delete_linked_records(sales_order):
 	frappe.delete_doc("Sales Order", sales_order, ignore_permissions=True)
 
 	return "success"
+
+
+
+@frappe.whitelist()
+def create_opportunity():
+	"""
+	Creates Opportunities for Sales Orders flagged for follow_up_for_next_project
+	and assigns a Task to follow_up_person from Compliance Sub Category
+	"""
+	today_date = getdate(today())
+	this_year = today_date.year
+	this_month = today_date.month
+
+	print(f"[INFO] Today's Date: {today_date}")
+
+	# Get all eligible Sales Orders
+	sales_orders = frappe.db.get_all(
+		"Sales Order",
+		filters={"follow_up_for_next_project": 1},
+		fields=["name", "customer", "status", "workflow_state", "company"]
+	)
+
+	for so in sales_orders:
+		# Fetch Sales Order Items with compliance fields
+		sales_order_items = frappe.get_all(
+			"Sales Order Item",
+			filters={"parent": so.name},
+			fields=[
+				"item_code", "item_name", "uom", "qty",
+				"brand", "item_group", "description",
+				"image", "base_rate", "base_amount", "rate", "amount",
+				"custom_compliance_subcategory as compliance_sub_category",
+				"custom_compliance_category as compliance_category"
+			]
+		)
+
+		for item in sales_order_items:
+			subcat_name = item.compliance_sub_category
+			if not subcat_name:
+				continue
+
+			compliance = frappe.get_doc("Compliance Sub Category", subcat_name)
+
+			# Only if repeat + notifications allowed
+			if not (compliance.allow_repeat and compliance.renew_notif):
+				continue
+
+			day = int(compliance.day or 1)
+			notif_days = int(float(compliance.renew_notif_days_before or 0))
+			repeat_on = compliance.repeat_on
+			scheduled_date = None
+
+			try:
+				if repeat_on == "Monthly":
+					scheduled_date = datetime(this_year, this_month, day).date()
+
+				elif repeat_on == "Quarterly":
+					for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
+						d = datetime(this_year, m, day).date()
+						if d >= today_date:
+							scheduled_date = d
+							break
+
+				elif repeat_on == "Half Yearly":
+					for m in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
+						d = datetime(this_year, m, day).date()
+						if d >= today_date:
+							scheduled_date = d
+							break
+
+				elif repeat_on == "Yearly":
+					if compliance.month:
+						m = datetime.strptime(compliance.month, "%B").month
+						scheduled_date = datetime(this_year, m, day).date()
+
+			except Exception as e:
+				print(f"[WARN] Skipping {subcat_name}: Invalid date - {e}")
+				continue
+
+			if not scheduled_date:
+				continue
+
+			notif_trigger_date = add_days(scheduled_date, -notif_days)
+			print(f"[DEBUG] For {subcat_name}: Scheduled on {scheduled_date}, Notify on {notif_trigger_date}")
+
+			if notif_trigger_date != today_date:
+				continue
+
+			# Skip if Opportunity already exists
+			existing_opportunity = frappe.db.exists("Opportunity", {"sales_order": so.name})
+			if existing_opportunity:
+				print(f"[SKIP] Opportunity already exists for Sales Order: {so.name}")
+				continue
+
+			try:
+				# Only create for active sales orders
+				if so.status not in ["Draft", "Closed", "Cancelled"] or so.workflow_state not in ["Pending", "Cancelled"]:
+					opportunity = frappe.new_doc("Opportunity")
+					opportunity.opportunity_from = "Customer"
+					opportunity.party_name = so.customer
+					opportunity.status = "Open"
+					opportunity.opportunity_type = "Sales"
+					opportunity.sales_order = so.name
+					opportunity.naming_series = "CRM-OPP-.YYYY.-"
+					opportunity.company = so.company
+
+					# Map Sales Order Items → Opportunity Items
+					for soi in sales_order_items:
+						opp_item = opportunity.append("items", {})
+						opp_item.item_code = soi.item_code
+						opp_item.item_name = soi.item_name
+						opp_item.uom = soi.uom
+						opp_item.qty = soi.qty
+						opp_item.brand = soi.brand
+						opp_item.item_group = soi.item_group
+						opp_item.description = soi.description
+						opp_item.image = soi.image
+						opp_item.base_rate = soi.base_rate
+						opp_item.base_amount = soi.base_amount
+						opp_item.rate = soi.rate
+						opp_item.amount = soi.amount
+
+						# Map compliance fields to Opportunity Item
+						opp_item.compliance_category = soi.compliance_category
+						opp_item.compliance_sub_category = soi.compliance_sub_category
+
+					opportunity.insert(ignore_permissions=True)
+					frappe.db.commit()
+
+					print(f"[SUCCESS] Created Opportunity: {opportunity.name} for {subcat_name}")
+
+					# Create and assign Task
+					follow_up_user = frappe.db.get_value("Employee", compliance.follow_up_person, "user_id")
+
+					try:
+						task = frappe.new_doc("Task")
+						task.subject = f"Follow up on Opportunity {opportunity.name}"
+						task.reference_type = "Opportunity"
+						task.reference_name = opportunity.name
+						task.status = "Open"
+						task.description = f"Follow up for compliance sub category: {subcat_name}"
+						task.assigned_by = frappe.session.user
+						task.company = opportunity.company
+
+						task.insert(ignore_permissions=True)
+						frappe.db.commit()
+
+						if follow_up_user:
+							todo = frappe.new_doc("ToDo")
+							todo.owner = follow_up_user
+							todo.assigned_by = frappe.session.user
+							todo.allocated_to = follow_up_user
+							todo.reference_type = "Task"
+							todo.reference_name = task.name
+							todo.description = f"Follow up for compliance sub category: {subcat_name}"
+							todo.status = "Open"
+							todo.priority = "Medium"
+							todo.date = today()
+							todo.insert(ignore_permissions=True)
+							frappe.db.commit()
+
+						print(f"[SUCCESS] Created and assigned Task {task.name} to {follow_up_user}")
+
+					except Exception as e:
+						print(f"[ERROR] Failed to create/assign Task for {subcat_name}: {e}")
+
+			except Exception as e:
+				print(f"[ERROR] Failed to create opportunity for {subcat_name}: {e}")
+
+
+def set_compliance_fields(doc, method):
+	"""
+	For each item , this function fetches the related compliance category 
+	and subcategory 
+	"""
+	for item in doc.items:
+		if item.item_code:
+			subcat =  frappe.db.get_value(
+				"Compliance Sub Category",
+				 {"item_code": item.item_code},
+				 ["compliance_category", "name"],
+				 as_dict=True
+			)
+			if subcat:
+				item.custom_compliance_category     = subcat.compliance_category
+				item.custom_compliance_subcategory  = subcat.name

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -1,10 +1,10 @@
+from datetime import datetime
+
 import frappe
 from frappe import _
 from frappe.utils import add_days, add_months, date_diff, getdate, json, today
 from one_compliance.one_compliance.utils import add_custom as add_assign
 from one_compliance.one_compliance.utils import create_todo, get_users_with_role
-
-from datetime import datetime
 
 
 @frappe.whitelist()
@@ -331,8 +331,8 @@ def create_opportunity():
 	# Get all eligible Sales Orders
 	sales_orders = frappe.db.get_all(
 		"Sales Order",
-		filters={"follow_up_for_next_project": 1},
-		fields=["name", "customer", "status", "workflow_state", "company"]
+		filters={"follow_up_for_next_project": 1, "follow_up_completed": 0},
+		fields=["name", "customer", "status", "workflow_state", "company", "follow_up_completed"]
 	)
 
 	for so in sales_orders:
@@ -404,7 +404,7 @@ def create_opportunity():
 			# Skip if Opportunity already exists
 			existing_opportunity = frappe.db.exists("Opportunity", {"sales_order": so.name})
 			if existing_opportunity:
-				print(f"[SKIP] Opportunity already exists for Sales Order: {so.name}")
+				print(f"[SKIP] Opportunity already exists for Opportunity Date : {today_date}")
 				continue
 
 			try:
@@ -418,6 +418,7 @@ def create_opportunity():
 					opportunity.sales_order = so.name
 					opportunity.naming_series = "CRM-OPP-.YYYY.-"
 					opportunity.company = so.company
+					opportunity.opportunity_date = today_date
 
 					# Map Sales Order Items → Opportunity Items
 					for soi in sales_order_items:
@@ -440,6 +441,9 @@ def create_opportunity():
 						opp_item.compliance_sub_category = soi.compliance_sub_category
 
 					opportunity.insert(ignore_permissions=True)
+					frappe.db.commit()
+     
+					frappe.db.set_value("Sales Order", so.name, "follow_up_completed", 1)
 					frappe.db.commit()
 
 					print(f"[SUCCESS] Created Opportunity: {opportunity.name} for {subcat_name}")

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -452,25 +452,14 @@ def create_opportunity():
 					follow_up_user = frappe.db.get_value("Employee", compliance.follow_up_person, "user_id")
 
 					try:
-						task = frappe.new_doc("Task")
-						task.subject = f"Follow up on Opportunity {opportunity.name}"
-						task.reference_type = "Opportunity"
-						task.reference_name = opportunity.name
-						task.status = "Open"
-						task.description = f"Follow up for compliance sub category: {subcat_name}"
-						task.assigned_by = frappe.session.user
-						task.company = opportunity.company
-
-						task.insert(ignore_permissions=True)
-						frappe.db.commit()
 
 						if follow_up_user:
 							todo = frappe.new_doc("ToDo")
 							todo.owner = follow_up_user
 							todo.assigned_by = frappe.session.user
 							todo.allocated_to = follow_up_user
-							todo.reference_type = "Task"
-							todo.reference_name = task.name
+							todo.reference_type = "Opportunity"
+							todo.reference_name = opportunity.name
 							todo.description = f"Follow up for compliance sub category: {subcat_name}"
 							todo.status = "Open"
 							todo.priority = "Medium"
@@ -478,10 +467,10 @@ def create_opportunity():
 							todo.insert(ignore_permissions=True)
 							frappe.db.commit()
 
-						print(f"[SUCCESS] Created and assigned Task {task.name} to {follow_up_user}")
+						print(f"[SUCCESS] Created and assigned Todo {todo.name} to {follow_up_user}")
 
 					except Exception as e:
-						print(f"[ERROR] Failed to create/assign Task for {subcat_name}: {e}")
+						print(f"[ERROR] Failed to create Todo for {subcat_name}: {e}")
 
 			except Exception as e:
 				print(f"[ERROR] Failed to create opportunity for {subcat_name}: {e}")

--- a/one_compliance/setup.py
+++ b/one_compliance/setup.py
@@ -19,6 +19,7 @@ from one_compliance.custom.custom_field.task import get_task_custom_fields
 from one_compliance.custom.custom_field.terms_and_conditions import get_terms_and_conditions_custom_fields
 from one_compliance.custom.custom_field.timesheet import get_timesheet_custom_fields
 from one_compliance.custom.custom_field.todo import get_todo_custom_fields
+from one_compliance.custom.custom_field.opportunity_item import get_opportunity_item_custom_fields
 
 # Custom property setter method imports
 from one_compliance.custom.property_setter.contact_email import get_contact_email_property_setters
@@ -151,6 +152,7 @@ def get_custom_fields():
 	custom_fields.update(get_terms_and_conditions_custom_fields())
 	custom_fields.update(get_timesheet_custom_fields())
 	custom_fields.update(get_todo_custom_fields())
+ 	custom_fields.update(get_opportunity_item_custom_fields())
 	custom_fields.update(())
 	return custom_fields
 

--- a/one_compliance/setup.py
+++ b/one_compliance/setup.py
@@ -152,7 +152,7 @@ def get_custom_fields():
 	custom_fields.update(get_terms_and_conditions_custom_fields())
 	custom_fields.update(get_timesheet_custom_fields())
 	custom_fields.update(get_todo_custom_fields())
- 	custom_fields.update(get_opportunity_item_custom_fields())
+	custom_fields.update(get_opportunity_item_custom_fields())
 	custom_fields.update(())
 	return custom_fields
 


### PR DESCRIPTION
## Feature description
Create Opportunity from Sales Order

1. Bring a field “Followup for next Project” (checkbox) in Sales Order.
2. The Compliance Sub Category  have a field “Send Renew Notification to Customer”, based on this date a new opportunity 
    has to be created for the Customer
4. Add a checkbox “Followup Required” in Compliance Sub Category.
5.  A task has  to be created to the Opportunity to follow up the Customer. Assign this task to the Employee in the Project                       
      Template of this Compliance Sub Category. (Bring a new field “Follow up Person” in compliance Sub category)


## Solution description
Enabled opportunity and Task creation  from sales order if Followup for next Project checkbox is checked in sales order for that compliance category and task is assigned to the follow up person in compliance category.

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![image](https://github.com/user-attachments/assets/ab6de5ed-a402-47e0-8ac0-7affd403afe1)
![image](https://github.com/user-attachments/assets/ad16c5e6-d3e3-4476-be06-39f88741d39b)
![image](https://github.com/user-attachments/assets/f8dc5107-f6ce-4fac-8ac7-eb2abb165a21)



## Was this feature tested on the browsers?
  - Chrome