### PR TITLE
fix: removed setting sales order as proforma on creation if sales ord…

### DIFF
--- a/one_compliance/custom/custom_field/sales_order.py
+++ b/one_compliance/custom/custom_field/sales_order.py
@@ -18,6 +18,7 @@ def get_sales_order_custom_fields():
 				"fieldtype": "Date",
 				"insert_after": "transaction_date",
 				"label": "Invoice Generation Date",
+				"read_only": 1,
 			},
 			{
 				"allow_on_submit": 1,

--- a/one_compliance/one_compliance/doc_events/project.py
+++ b/one_compliance/one_compliance/doc_events/project.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe import _
 from frappe.email.doctype.notification.notification import get_context
-from frappe.utils import add_days, getdate, today
+from frappe.utils import add_days, getdate
 from one_compliance.one_compliance.doc_events.task import (
 	create_sales_order,
 	get_rate_from_compliance_agreement,
@@ -96,11 +96,7 @@ def project_after_insert(doc, method):
 				if sales_order:
 					doc.sales_order = sales_order
 					doc.save(ignore_permissions=True)
-			if sales_order:
-				frappe.db.set_value("Sales Order", sales_order, "status", "Proforma Invoice")
-				frappe.db.set_value("Sales Order", sales_order, "workflow_state", "Proforma Invoice")
-				frappe.db.set_value("Sales Order", sales_order, "invoice_generation_date", today())
-			else:
+			if not sales_order:
 				payment_terms = None
 				rate = 0
 				if frappe.db.exists('Compliance Agreement', doc.compliance_agreement):


### PR DESCRIPTION
…er exist

## Reason for PR
- When creating sales orders with Create Project checked, Sales Orders are marked as Proforma Invoice, which is wrong

## Changed Made
- Removed script setting sales order as Proforma Invoice when project is inserted.
- Adjusted conditions to let sales order creation on project insertion to work as intended
