### PR TITLE
fix: add validation before viewing credentials

### DIFF
--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
@@ -841,6 +841,7 @@ function cusomerCredentials(subCategory, customer){
 				fieldname: 'purpose',
 				fieldtype: 'Link',
 				options: 'Credential Type',
+				reqd: 1,
 				get_query: function () {
 					return {
 						filters: {
@@ -852,6 +853,10 @@ function cusomerCredentials(subCategory, customer){
 		],
 		primary_action_label: 'View Credential',
 		primary_action(values) {
+			if (!values.purpose) {
+				frappe.msgprint(__('Please select a Purpose before viewing credentials.'));
+				return;
+			}
 			frappe.call({
 				method:'one_compliance.one_compliance.utils.view_credential_details',
 				args:{


### PR DESCRIPTION
## Feature description

- **[ ] TASK-2025-02513**
- **Issue Fixed:**

    When clicking the key icon in the Task Management Tool, a pop-up opens where the user can select a Purpose to      view stored credentials.
    If the user clicks “View Credentials” without selecting a purpose, the system throws a server error instead of showing a validation message.
**Error Message:**
    Server Error
    TypeError: view_credential_details() missing 1 required positional argument: 'purpose'


-    prevent server error when viewing credentials without selecting purpose

## Solution description

- prevent server error when viewing credentials without selecting purpose
- Added validation to ensure a purpose is selected before calling the backend.
- Added reqd: 1 to the Purpose field in the credential popup dialog to ensure users select a Purpose before viewing credentials. This prevents accidental backend calls without required input.
- Now shows a message instead of throwing a server error.

## Output screenshots (optional)

[Screencast from 27-10-25 10:33:00 AM IST.webm](https://github.com/user-attachments/assets/227af353-e4bd-4e0e-bbda-d81bbedb1d5a)

<img width="1374" height="946" alt="image" src="https://github.com/user-attachments/assets/2180b753-3f70-4748-92c3-bf86c4a272f7" />


## Areas affected and ensured
Task Management Tool

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
