### PR TITLE
feat:Pagination for Task Management Tool

### DIFF
--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.css
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.css
@@ -1,75 +1,105 @@
 /* Style to each task card */
 .card {
-        margin: 10px;
-        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-        border: None;
-        border-radius: 8px;
-        overflow: hidden;
-        padding: 2px;
-        background-color: aliceblue;
-    }
-    /* background color to the main page */
-    .layout-main-section.frappe-card {
-      background-color: #fdf7f9;
-    }
-    /* background color to the filter form */
-    .page-form {
-      background-color: #fdf7f9;
-    }
-    /* transparent background to the header tag */
-    .list-row-head {
-      background-color: transparent;
-    }
-    /* padding to each card body */
-    .card-body {
-        padding: 20px;
-    }
-    /* style to card title */
-    .card-title {
-        font-size: 1rem;
-        margin-bottom: 10px;
-    }
-    /* Alignment for card text section */
-    .card-text {
-        margin-bottom: 15px;
-    }
-    /* Alignment for button icon section */
-    .btn-icon {
-        margin-right: 2px;
-        padding: 8px;
-        margin-bottom: 5px;
-    }
-    /* Alignment for add assignee button icon */
-    .rounded-circle {
-      margin-top:5px;
-      padding: 0px 4px;
-      position: absolute;
-      right: 30px;
-    }
-    /* style to the customer link */
-    .customer-link {
-        display: inline-block;
-        max-width: 100%; /* Adjust as needed */
-        overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-    }
+		margin: 20px 10px ;
+		box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+		border: None;
+		border-radius: 8px;
+		overflow: hidden;
+		padding: 2px;
+		background-color: rgb(242, 242, 243);
+	}
+	/* background color to the main page */
+	.layout-main-section.frappe-card {
+	  background-color: #ffffff;
+	}
+	/* background color to the filter form */
+	.page-form {
+	  background-color: #ffffff;
+	}
+	/* transparent background to the header tag */
+	.list-row-head {
+	  background-color: transparent;
+	}
+	/* padding to each card body */
+	.card-body {
+		padding: 20px;
+	}
+	/* style to card title */
+	.card-title {
+		font-size: 1rem;
+		margin-bottom: 10px;
+	}
+	/* Alignment for card text section */
+	.card-text {
+		margin-bottom: 15px;
+	}
+	/* Alignment for button icon section */
+	.btn-icon {
+		margin-right: 2px;
+		padding: 8px;
+		margin-bottom: 5px;
+	}
+	/* Alignment for add assignee button icon */
+	.rounded-circle {
+	  margin-top:5px;
+	  padding: 0px 4px;
+	  position: absolute;
+	  right: 30px;
+	}
+	/* style to the customer link */
+	.customer-link {
+		display: inline-block;
+		max-width: 100%; /* Adjust as needed */
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+	}
 
-    .customer-link:hover {
-        max-width: none;
-        white-space: nowrap;
-        overflow: visible;
-    }
-    /* style to the project link */
-    .project-link{
-      display: inline-block;
-      max-width: 100%; /* Adjust as needed */
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-    }
+	.customer-link:hover {
+		max-width: none;
+		white-space: nowrap;
+		overflow: visible;
+	}
+	/* style to the project link */
+	.project-link{
+	  display: inline-block;
+	  max-width: 100%; /* Adjust as needed */
+	  overflow: hidden;
+	  white-space: nowrap;
+	  text-overflow: ellipsis;
+	}
 
-    .project-link:hover {
-        max-width: none;
-        white-space: normal;
-    }
+	.project-link:hover {
+		max-width: none;
+		white-space: normal;
+	}
+
+	#pagination-container .btn {
+		display: inline-block;
+		margin: 0 5px;
+		padding: 5px 12px;
+		font-size: 14px;
+		border-radius: 5px;
+		border: 1px solid #3e89ec;
+		color: #007bff;
+		background-color: white;
+		cursor: pointer;
+		transition: all 0.2s ease;
+	}
+
+	#pagination-container .btn:hover {
+		background-color: #1d7be0;
+		color: white;
+	}
+
+	#pagination-container .btn:disabled {
+		cursor: not-allowed;
+		opacity: 0.6;
+
+
+	}
+
+	.page-size-selector {
+	display: flex;
+	align-items: center;
+	}

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.html
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.html
@@ -1,89 +1,98 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
 <div class="frappe-list">
   <div class="result">
-    <header class="level list-row-head text-muted">
-      <div class="level-left list-header-subject" style="margin-top:5px;">
-          <div class="col-md-2 text-center">Task</div>
-          <div class="col-md-2 text-center">Start - End Date</div>
-          <div class="col-md-2 text-center">Department</div>
-          <div class="col-md-2 text-center">Compliance Sub Category</div>
-          <div class="col-md-2 text-center assignee-section">Assigned To</div>
-          <div class="col-md-2 text-center completed-by-section">Completed By</div>
-          <div class="col-md-2">Status</div>
-      </div>
-    </header>
+	<header class="level list-row-head text-muted">
+	  <div class="level-left list-header-subject" style="margin-top:5px;">
+		  <div class="col-md-2 text-center">Task</div>
+		  <div class="col-md-2 text-center">Start - End Date</div>
+		  <div class="col-md-2 text-center">Department</div>
+		  <div class="col-md-2 text-center">Compliance Sub Category</div>
+		  <div class="col-md-2 text-center assignee-section">Assigned To</div>
+		  <div class="col-md-2 text-center completed-by-section">Completed By</div>
+		  <div class="col-md-2">Status</div>
+	  </div>
+	</header>
 
-    {% for data in task_list %}
-    <div class="card task-entry">
-        <div class="card-body">
-            <div class="row">
-                <div class="col-md-2" style="padding: inherit;">
-                    <a class="card-title" style="color: orange;" href="/app/task/{{data.name}}">{{ data.subject }}</a><br>
-                    <a class="card-subtitle project-link" href="/app/project/{{ data.project }}" color="{{ data.color }}">{{ data.project_name }}</a>
-                    {% if data.customer %}
-                    <p class="card-text customer-link">
-                        Customer: <a style="font-weight:bold;" href="/app/customer/{{data.customer}}">{{ data.customer }}</a>
-                    </p>
-                    {% endif %}
-                </div>
-                <div class="col-md-2 text-center" style="padding: inherit;">
-                    {{ data.exp_start_date }} <br>- {{ data.exp_end_date }}
-                </div>
-                <a class="col-md-2 text-center" style="padding: inherit;" href="/app/department/{{ data.department }}">
-                    {{ data.department }}
-                </a>
-                <a class="col-md-2 text-center" style="padding: inherit;" href="/app/compliance-sub-category/{{ data.compliance_sub_category }}">
-                    {{ data.compliance_sub_category }}
-                </a>
-                <div class="col-md-2 text-center" style="padding: inherit; position:relative;">
-                    <p class="card-text assignee-section">
-                        {% if data._assign %}
-                            {% for assignee in data._assign %}
-                                <a href="/app/employee/{{ assignee.employee_id }}">{{ assignee.employee_name }}</a><br>
-                            {% endfor %}
-                        {% endif %}
-                        <button class="btn btn-sm rounded-circle addAssigneeBtn" task-id="{{ data.name }}">
-                            <i class="fas fa-plus"></i>
-                        </button>
-                    </p>
-                    <p class="card-text completed-by-section">
-                        <a href="/app/employee/{{ data.completed_by_id }}" style="padding-left: 15px;">{{ data.completed_by_name }}</a><br>
-                    </p>
-                </div>
-                <div class="col-md-1 text-center" style="padding: inherit;">
-                  <p status-span="{{ data.status }}" task-name="{{ data.subject }}" project-id="{{ data.project }}" task-id="{{ data.name }}">{{ data.status }}</p>
-                  <!-- Tag to show the start time -->
-                  <p class="start-time" task-id="{{ data.name }}" project-id="{{ data.project }}" ></p>
-                </div>
-                <div class="col-md-1" style="padding: inherit;">
-                  <div class="">
-                    <!-- Button for start -->
-                    <button class="btn btn-outline-warning btn-icon startButton" task-id="{{ data.name }}" project-id="{{ data.project }}" data-toggle="tooltip" title="Start Timer">
-                        <i class="fas fa-play"></i>
-                    </button>
-                    <!-- Button for timesheet -->
-                    <button class="btn btn-outline-primary btn-icon timeEntryButton" task-id="{{ data.name }}" project-id="{{ data.project }}" assignees="{{ data.employee_names }}" data-toggle="tooltip" title="Time Sheet">
-                        <i class="fas fa-clock"></i>
-                    </button>
-                    <!-- Button for view documents -->
-                    <button class="btn btn-outline-info btn-icon documentButton" sub-category="{{ data.compliance_sub_category }}" customer="{{ data.customer }}" data-toggle="tooltip" title="Documents">
-                        <i class="fas fa-file-alt"></i>
-                    </button>
-                    <!-- Button for view credentials -->
-                    <button class="btn btn-outline-success btn-icon credentialButton" sub-category="{{ data.compliance_sub_category }}" customer="{{ data.customer }}" data-toggle="tooltip" title="Credentials">
-                        <i class="fas fa-key"></i>
-                    </button>
-                  </div>
-                  <div style="padding-left: 5px;">
-                    <!-- Button for payment entry -->
-                    <button class="btn btn-outline-success btn-icon paymentEntryButton" task-id="{{ data.name }}" is-payable="{{ data.custom_is_payable }}" payable-amount="{{ data.custom_payable_amount }}" mode-of-payment="{{ data.custom_mode_of_payment }}" ref-num="{{ data.custom_reference_number }}" ref-date="{{ data.custom_reference_date }}" remark="{{ data.custom_user_remark }}" data-toggle="tooltip" title="Payment Entry">
-                        <i class="fas fa-wallet"></i>
-                    </button>
-                  </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    {% endfor %}
+	{% for data in task_list %}
+	<div class="card task-entry">
+		<div class="card-body">
+			<div class="row">
+				<div class="col-md-2" style="padding: inherit;">
+					<a class="card-title" style="color: orange;" href="/app/task/{{data.name}}">{{ data.subject }}</a><br>
+					<a class="card-subtitle project-link" href="/app/project/{{ data.project }}" color="{{ data.color }}">{{ data.project_name }}</a>
+					{% if data.customer %}
+					<p class="card-text customer-link">
+						Customer: <a style="font-weight:bold;" href="/app/customer/{{data.customer}}">{{ data.customer }}</a>
+					</p>
+					{% endif %}
+				</div>
+				<div class="col-md-2 text-center" style="padding: inherit;">
+					{{ data.exp_start_date }} <br>- {{ data.exp_end_date }}
+				</div>
+				<a class="col-md-2 text-center" style="padding: inherit;" href="/app/department/{{ data.department }}">
+					{{ data.department }}
+				</a>
+				<a class="col-md-2 text-center" style="padding: inherit;" href="/app/compliance-sub-category/{{ data.compliance_sub_category }}">
+					{{ data.compliance_sub_category }}
+				</a>
+				<div class="col-md-2 text-center" style="padding: inherit; position:relative;">
+					<p class="card-text assignee-section">
+						{% if data._assign %}
+							{% for assignee in data._assign %}
+								<a href="/app/employee/{{ assignee.employee_id }}">{{ assignee.employee_name }}</a><br>
+							{% endfor %}
+						{% endif %}
+						<button class="btn btn-sm rounded-circle addAssigneeBtn" task-id="{{ data.name }}">
+							<i class="fas fa-plus"></i>
+						</button>
+					</p>
+					<p class="card-text completed-by-section">
+						<a href="/app/employee/{{ data.completed_by_id }}" style="padding-left: 15px;">{{ data.completed_by_name }}</a><br>
+					</p>
+				</div>
+				<div class="col-md-1 text-center" style="padding: inherit;">
+				  <p status-span="{{ data.status }}" task-name="{{ data.subject }}" project-id="{{ data.project }}" task-id="{{ data.name }}">{{ data.status }}</p>
+				  <!-- Tag to show the start time -->
+				  <p class="start-time" task-id="{{ data.name }}" project-id="{{ data.project }}" ></p>
+				</div>
+				<div class="col-md-1" style="padding: inherit;">
+				  <div class="">
+					<!-- Button for start -->
+					<button class="btn btn-outline-warning btn-icon startButton" task-id="{{ data.name }}" project-id="{{ data.project }}" data-toggle="tooltip" title="Start Timer">
+						<i class="fas fa-play"></i>
+					</button>
+					<!-- Button for timesheet -->
+					<button class="btn btn-outline-primary btn-icon timeEntryButton" task-id="{{ data.name }}" project-id="{{ data.project }}" assignees="{{ data.employee_names }}" data-toggle="tooltip" title="Time Sheet">
+						<i class="fas fa-clock"></i>
+					</button>
+					<!-- Button for view documents -->
+					<button class="btn btn-outline-info btn-icon documentButton" sub-category="{{ data.compliance_sub_category }}" customer="{{ data.customer }}" data-toggle="tooltip" title="Documents">
+						<i class="fas fa-file-alt"></i>
+					</button>
+					<!-- Button for view credentials -->
+					<button class="btn btn-outline-success btn-icon credentialButton" sub-category="{{ data.compliance_sub_category }}" customer="{{ data.customer }}" data-toggle="tooltip" title="Credentials">
+						<i class="fas fa-key"></i>
+					</button>
+				  </div>
+				  <div style="padding-left: 5px;">
+					<!-- Button for payment entry -->
+					<button class="btn btn-outline-success btn-icon paymentEntryButton" task-id="{{ data.name }}" is-payable="{{ data.custom_is_payable }}" payable-amount="{{ data.custom_payable_amount }}" mode-of-payment="{{ data.custom_mode_of_payment }}" ref-num="{{ data.custom_reference_number }}" ref-date="{{ data.custom_reference_date }}" remark="{{ data.custom_user_remark }}" data-toggle="tooltip" title="Payment Entry">
+						<i class="fas fa-wallet"></i>
+					</button>
+				  </div>
+				</div>
+			</div>
+		</div>
+	</div>
+	{% endfor %}
   </div>
+
+	<div id="pagination-container" class="text-center" style="margin-top: 10px;"></div>
+		<div class="btn-group ml-3 page-length-buttons" role="group">
+			<button class="btn btn-sm btn-default page-length-btn active" data-length="20">20</button>
+			<button class="btn btn-sm btn-default page-length-btn" data-length="100">100</button>
+			<button class="btn btn-sm btn-default page-length-btn" data-length="500">500</button>
+			<button class="btn btn-sm btn-default page-length-btn" data-length="2500">2500</button>
+		</div>
+	</div>
 </div>

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.html
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.html
@@ -58,7 +58,7 @@
 				<div class="col-md-1" style="padding: inherit;">
 				  <div class="">
 					<!-- Button for start -->
-					<button class="btn btn-outline-warning btn-icon startButton" task-id="{{ data.name }}" project-id="{{ data.project }}" data-toggle="tooltip" title="Start Timer">
+					<button class="btn btn-outline-warning btn-icon startButton" task-id="{{ data.name }}" project-id="{{ data.project }}" 	assignees="{{ data.employee_names }}" data-toggle="tooltip" title="Start Timer">
 						<i class="fas fa-play"></i>
 					</button>
 					<!-- Button for timesheet -->

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
@@ -30,335 +30,290 @@ frappe.pages['task-management-tool'].on_page_show = function (wrapper) {
 	}
 }
 
+/*
+Creates and configures all filter fields for the Task Management Tool page.
+Each filter refreshes the task list when its value changes.
+*/
 function make_filters(page) {
-	var project_id = localStorage.getItem('selected_project_id');
-	let taskField = page.add_field({
-		label: __("Task"),
-		fieldname: "task",
-		fieldtype: "Link",
-		options: "Task",
-		change() {
-			if (page.fields_dict.task.get_value()) {
-		  refresh_tasks(page);
-	  }
-		}
-	});
-	page.fields_dict.task.$input.on('change', function() {
-		if (!page.fields_dict.task.get_value()) {
-				refresh_tasks(page);
-		}
-  });
-	let projectField = page.add_field({
-		label: __("Project"),
-		fieldname: "project",
-		fieldtype: "Link",
-		options: "Project",
-		default:project_id,
-		change() {
-			if (page.fields_dict.project.get_value()) {
-		  refresh_tasks(page);
-	  }
-		}
-	});
-	localStorage.removeItem('selected_project_id');
-	page.fields_dict.project.$input.on('change', function() {
-		if (!page.fields_dict.project.get_value()) {
-			refresh_tasks(page);
-		}
-  });
-	let customerField = page.add_field({
-		label: __("Customer"),
-		fieldname: "customer",
-		fieldtype: "Link",
-		options:"Customer",
-		change() {
-			if (page.fields_dict.customer.get_value()) {
-		  refresh_tasks(page);
-	  }
-		}
-	});
-	page.fields_dict.customer.$input.on('change', function() {
-		if (!page.fields_dict.customer.get_value()) {
-				refresh_tasks(page);
-		}
-  });
-	let employeeField = page.add_field({
-		label: __("Employee"),
-		fieldname: "employee",
-		fieldtype: "Link",
-		options: "User",
-		default: get_employee_id(),
-		change() {
-			if (page.fields_dict.employee.get_value()) {
-		  refresh_tasks(page);
-	  }
+	const project_id = localStorage.getItem('selected_project_id');
+
+	const filters = [
+		{ label: "Task", fieldname: "task", options: "Task" },
+		{ label: "Project", fieldname: "project", options: "Project", default: project_id },
+		{ label: "Customer", fieldname: "customer", options: "Customer" },
+		{
+			label: "Employee",
+			fieldname: "employee",
+			options: "User",
+			default: get_employee_id(),
+			read_only: frappe.session.user !== "Administrator"
 		},
-		read_only: frappe.session.user === 'Administrator' ? 0 : 1
+		{ label: "Employee Group", fieldname: "employee_group", options: "Employee Group" },
+		{ label: "Department", fieldname: "department", options: "Department" },
+		{ label: "Compliance Sub Category", fieldname: "compliance_sub_category", options: "Compliance Sub Category" },
+		{ label: "From Date", fieldname: "from_date", fieldtype: "Date" },
+		{ label: "To Date", fieldname: "to_date", fieldtype: "Date" }
+	];
+
+	localStorage.removeItem('selected_project_id');
+
+	const bind_refresh = (fieldname) => {
+		let field = page.fields_dict[fieldname];
+		field.$input.on("change", function () {
+			refresh_tasks(page);
+		});
+	};
+
+	filters.forEach(f => {
+		page.add_field({
+			label: __(f.label),
+			fieldname: f.fieldname,
+			fieldtype: f.fieldtype || "Link",
+			options: f.options,
+			default: f.default || "",
+			read_only: f.read_only ? 1 : 0,
+			change() {
+				if (page.fields_dict[f.fieldname].get_value()) {
+					refresh_tasks(page);
+				}
+			}
+		});
+		bind_refresh(f.fieldname);
 	});
-	page.fields_dict.employee.$input.on('change', function() {
-		if (!page.fields_dict.employee.get_value()) {
-				refresh_tasks(page);
-		}
-  });
-	let employeeGroupField = page.add_field({
-		label: __("Employee Group"),
-		fieldname: "employee_group",
-		fieldtype: "Link",
-		options: "Employee Group",
-		change() {
-			if (page.fields_dict.employee_group.get_value()) {
-		  refresh_tasks(page);
-	  }
-		}
-	});
-	page.fields_dict.employee_group.$input.on('change', function() {
-		if (!page.fields_dict.employee_group.get_value()) {
-				refresh_tasks(page);
-		}
-  });
-	let categoryField = page.add_field({
-		label: __("Department"),
-		fieldname: "department",
-		fieldtype: "Link",
-		options: "Department",
-		change() {
-			if (page.fields_dict.department.get_value()) {
-		  refresh_tasks(page);
-	  }
-		}
-	});
-	page.fields_dict.department.$input.on('change', function() {
-		if (!page.fields_dict.department.get_value()) {
-				refresh_tasks(page);
-		}
-  });
-	let subcategoryField = page.add_field({
-		label: __("Compliance Sub Category"),
-		fieldname: "compliance_sub_category",
-		fieldtype: "Link",
-		options: "Compliance Sub Category",
-		change() {
-			if (page.fields_dict.compliance_sub_category.get_value()) {
-		  refresh_tasks(page);
-	  }
-		}
-	});
-	page.fields_dict.compliance_sub_category.$input.on('change', function() {
-		if (!page.fields_dict.compliance_sub_category.get_value()) {
-				refresh_tasks(page);
-		}
-  });
-	let fromDateField = page.add_field({
-		label: __("From Date"),
-		fieldname: "from_date",
-		fieldtype: "Date"
-	});
-	page.fields_dict.from_date.$input.off('change').on('change', function() {
-		refresh_tasks(page);
-	});
-	let toDateField = page.add_field({
-		label: __("To Date"),
-		fieldname: "to_date",
-		fieldtype: "Date"
-	});
-	page.fields_dict.to_date.$input.off('change').on('change', function() {
-	  refresh_tasks(page);
-  });
-	let status = page.add_field({
+
+	page.add_field({
 		label: __("Status"),
 		fieldname: "status",
 		fieldtype: "Select",
 		options: [
-				{},
-				{ label: "Open", value: "open" },
-				{ label: "Working", value: "working" },
-				{ label: "Pending Review", value: "pending_review" },
-				{ label: "Overdue", value: "overdue" },
-				{ label: "Hold", value: "hold" },
-				{ label: "Completed", value: "completed" },
-				{ label: "Cancelled", value: "cancelled" },
-			],
-			default: "",
+			{},
+			{ label: "Open", value: "open" },
+			{ label: "Working", value: "working" },
+			{ label: "Pending Review", value: "pending_review" },
+			{ label: "Overdue", value: "overdue" },
+			{ label: "Hold", value: "hold" },
+			{ label: "Completed", value: "completed" },
+			{ label: "Cancelled", value: "cancelled" },
+		],
+		default: "",
 		change() {
 			refresh_tasks(page);
 		}
 	});
 }
 
+/*
+Determines which employee ID to use as default for filters.
+Returns blank for Administrator, otherwise returns current session user.
+*/
+
 function get_employee_id() {
-	if (frappe.session.user === 'Administrator') {
-		return '';
-	}
-		else {
-				return frappe.session.user
-		}
+	return frappe.session.user === "Administrator" ? "" : frappe.session.user;
 }
 
+/*
+Fetches and displays filtered task data based on selected filters.
+Called whenever a filter field changes or the page is refreshed.
+*/
+
 function refresh_tasks(page, reset_page = false) {
-	if (reset_page) {
-		page.current_page = 1;
-	}
+	if (reset_page) page.current_page = 1;
 
-	// Clear existing tasks and pagination from the page
-	page.body.find(".frappe-list").remove();
-	page.body.find(".pagination-container").remove();
+	page.body.find(".frappe-list, .pagination-container").remove();
 
-	const selectedStatus = page.fields_dict.status.get_value();
-	const taskName = page.fields_dict.task.get_value();
-	const projectName = page.fields_dict.project.get_value();
-	const customerName = page.fields_dict.customer.get_value();
+	const selected_status = page.fields_dict.status.get_value();
+	const task_name = page.fields_dict.task.get_value();
+	const project_name = page.fields_dict.project.get_value();
+	const customer_name = page.fields_dict.customer.get_value();
 	const department = page.fields_dict.department.get_value();
-	const subCategory = page.fields_dict.compliance_sub_category.get_value();
+	const sub_category = page.fields_dict.compliance_sub_category.get_value();
 	const employee = page.fields_dict.employee.get_value();
-	const employeeGroup = page.fields_dict.employee_group.get_value();
+	const employee_group = page.fields_dict.employee_group.get_value();
 	const from_date = page.fields_dict.from_date.get_value();
 	const to_date = page.fields_dict.to_date.get_value();
 
 	frappe.call({
 		method: "one_compliance.one_compliance.page.task_management_tool.task_management_tool.get_task",
 		args: {
-			status: selectedStatus,
-			task: taskName,
-			project: projectName,
-			customer: customerName,
-			department: department,
-			sub_category: subCategory,
-			employee: employee,
-			employee_group: employeeGroup,
-			from_date: from_date,
-			to_date: to_date,
+			status: selected_status,
+			task: task_name,
+			project: project_name,
+			customer: customer_name,
+			department,
+			sub_category,
+			employee,
+			employee_group,
+			from_date,
+			to_date,
 			page: page.current_page,
 			page_length: page.page_length
 		},
 		callback: (r) => {
 			if (r.message && r.message.tasks.length > 0) {
-				// Render the list of tasks to html page
-				$(frappe.render_template("task_management_tool", { task_list: r.message.tasks })).appendTo(page.body);
+				render_task_list(page, r.message.tasks);
 				setup_pagination(page, r.message.total_tasks);
-                setup_page_length_buttons(page);
+				setup_page_length_buttons(page);
+				initialize_task_actions(page);
+			} else {
+				show_no_task_found(page);
+			}
+		},
+		freeze: true,
+		freeze_message: "Loading Task List"
+	});
+}
 
+/**
+Refreshes and reloads the task list manually based on provided filters and updates UI interactions.
+*/
 
-				// Button action to add payment details
-				page.body.find(".paymentEntryButton").on("click", function () {
-							var taskId = $(this).attr("task-id");
-							var payableAmount = $(this).attr("payable-amount");
-							var modeOfPayment = $(this).attr("mode-of-payment");
-							var referenceNumber = $(this).attr("ref-num");
-							var referenceDate = $(this).attr("ref-date");
-							var userRemark = $(this).attr("remark");
-							paymentEntryDialog(taskId, payableAmount, modeOfPayment, referenceNumber, referenceDate, userRemark);
-			});
+function refresh_tasks_manually(page, selected_status, task_name, project_name, customer_name, department, sub_category, employee, employee_group, from_date, to_date) {
+	page.body.find(".frappe-list").remove();
 
-						// Button action to add assignees
-						page.body.find(".addAssigneeBtn").on("click", function () {
-							var taskName = $(this).attr("task-id");
-			  showAssignEntryDialog(taskName);
-			});
+	frappe.call({
+		method: "one_compliance.one_compliance.page.task_management_tool.task_management_tool.get_task",
+		args: {
+			status: selected_status,
+			task: task_name,
+			project: project_name,
+			customer: customer_name,
+			department,
+			sub_category,
+			employee,
+			employee_group,
+			from_date,
+			to_date
+		},
+		callback: (r) => {
+			if (r.message && r.message.length > 0) {
+				render_task_list(page, r.message);
+				initialize_task_actions(page);
+			} else {
+				show_no_task_found(page);
+			}
+		},
+		freeze: true,
+		freeze_message: "Loading Task List"
+	});
+}
 
-						// Initially hide the timesheet button
-						page.body.find(".timeEntryButton").hide();
+/**
+Renders task list into the page
+*/
 
-						// Button action to start the time
-						page.body.find(".startButton").on("click", function () {
-				var taskName = $(this).attr("task-id");
-				var projectName = $(this).attr("project-id");
+function render_task_list(page, tasks) {
+	$(frappe.render_template("task_management_tool", { task_list: tasks })).appendTo(page.body);
+}
 
-							var status = page.fields_dict.status.get_value();
-						if (status === 'completed' || status === 'hold' || status === 'cancelled') {
-							return; // If the task status is completed, hold, or cancelled, do not proceed
-						}
+/**
+Handles all task-related button bindings and UI updates
+*/
 
-				var currentTime = frappe.datetime.now_datetime();
-				var formattedTime = frappe.datetime.str_to_user(currentTime);
+function initialize_task_actions(page) {
+	const body = page.body;
 
-							// Save start time in local storage
-						localStorage.setItem("start-time-task-" + taskName + "-project-" + projectName, currentTime);
+	body.find(".paymentEntryButton").off().on("click", function () {
+		const task_id = $(this).attr("task-id");
+		const payable_amount = $(this).attr("payable-amount");
+		const mode_of_Payment = $(this).attr("mode-of-payment");
+		const reference_number = $(this).attr("ref-num");
+		const reference_date = $(this).attr("ref-date");
+		const user_remark = $(this).attr("remark");
+		payment_entry_dialog(task_id, payable_amount, mode_of_Payment, reference_number, reference_date, user_remark);
+	});
 
-				// Find the specific "start-time" paragraph associated with the task and project
-				var startTimeParagraph = page.body.find(".start-time[task-id='" + taskName + "'][project-id='" + projectName + "']");
-				startTimeParagraph.text(formattedTime);
+	body.find(".addAssigneeBtn").off().on("click", function () {
+		const task_name = $(this).attr("task-id");
+		show_assign_entry_dialog(task_name);
+	});
 
-							// Update the status of task to 'Working'
-							updateTaskStatus(page,taskName, projectName, "Working");
+	body.find(".timeEntryButton").hide();
 
-							// Hide the button once clicked
-							$(this).hide();
-							// Show the time sheet button
-							page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show();
-				});
+	body.find(".startButton").off().on("click", function () {
+		const task_name = $(this).attr("task-id");
+		const project_name = $(this).attr("project-id");
+		const status = page.fields_dict.status.get_value();
 
-						// Action of start-time field
-						page.body.find(".start-time").each(function () {
-						var taskName = $(this).attr("task-id");
-						var projectName = $(this).attr("project-id");
-						var startTime = localStorage.getItem("start-time-task-" + taskName + "-project-" + projectName);
+		if (["completed", "hold", "cancelled"].includes(status)) return;
 
-								// Check if a start time is retrieved from local storage
-								if (startTime) {
-								var storedDate = new Date(startTime);
-								var currentDate = new Date();
+		const current_time = frappe.datetime.now_datetime();
+		const formatted_time = frappe.datetime.str_to_user(current_time);
+		localStorage.setItem(`start-time-task-${task_name}-project-${project_name}`, current_time);
 
-										// Check if the retrieved start time belongs to the current day
-								if (storedDate.getDate() !== currentDate.getDate() || storedDate.getMonth() !== currentDate.getMonth() || storedDate.getFullYear() !== currentDate.getFullYear()) {
-									// If startTime doesn't belong to the current day, reset the values
-									localStorage.removeItem("start-time-task-" + taskName + "-project-" + projectName);
-									startTime = null;
-								}
-							}
-								// Check if a valid start time exists
-						if (startTime) {
-							var formattedTime = frappe.datetime.str_to_user(startTime);
-							$(this).text(formattedTime);
-										page.body.find(".startButton[task-id='" + taskName + "'][project-id='" + projectName + "']").hide(); // Hide the start button associated with the task and project
-								page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show(); // Show the time entry button associated with the task and project
-						}
-								else {
-										// If no valid start time exists
-										$(this).text("");
-										page.body.find(".startButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show(); // Show the start button associated with the task and project
-										page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").hide(); // Hide the time entry button associated with the task and project
-								}
-					});
+		body.find(`.start-time[task-id='${task_name}'][project-id='${project_name}']`).text(formatted_time);
+		update_task_status(page, task_name, project_name, "Working");
 
-						// Button action to enter timesheet
-						page.body.find(".timeEntryButton").on("click", function () {
-							var taskName = $(this).attr("task-id");
-							var projectName = $(this).attr("project-id");
-							var assignees = $(this).attr("assignees");
-							// Retrieve start time from local storage
-						var startTime = localStorage.getItem("start-time-task-" + taskName + "-project-" + projectName);
-			  showTimeEntryDialog(page, taskName, projectName, assignees, startTime);
-			});
+		$(this).hide();
+		body.find(`.timeEntryButton[task-id='${task_name}'][project-id='${project_name}']`).show();
+	});
 
-						// Button action to view Customer documents
-						page.body.find(".documentButton").on("click", function () {
-							var subCategory = $(this).attr("sub-category");
-							var customer = $(this).attr("customer");
-			  cusomerDocuments(subCategory, customer);
-			});
+	body.find(".start-time").each(function () {
+		const task_name = $(this).attr("task-id");
+		const project_name = $(this).attr("project-id");
+		let start_time = localStorage.getItem(`start-time-task-${task_name}-project-${project_name}`);
 
-						// Button action to view Customer credentials
-						page.body.find(".credentialButton").on("click", function () {
-							var subCategory = $(this).attr("sub-category");
-							var customer = $(this).attr("customer");
-			  cusomerCredentials(subCategory, customer);
-			});
+		if (start_time) {
+			const stored_date = new Date(start_time);
+			const current_date = new Date();
 
-						// Function to set colors to the status
-						set_status_colors(page);
-						// Function to hide assignee button for complated tasks
-						hide_add_assignee_button(page.fields_dict.status.get_value());
-						// Function to show assignee section or completed section based on task status
-						assignee_and_completed_by_section(page.fields_dict.status.get_value());
-				} else {
-			// If no tasks are found, append a message to the page body
-			$('<div class="frappe-list"></div>').appendTo(page.body).append('<div class="no-result text-muted flex justify-center align-center" style="text-align: center;"><p>No Task found with matching filters.</p></div>');
+			if (
+				stored_date.getDate() !== current_date.getDate() ||
+				stored_date.getMonth() !== current_date.getMonth() ||
+				stored_date.getFullYear() !== current_date.getFullYear()
+			) {
+				localStorage.removeItem(`start-time-task-${task_name}-project-${project_name}`);
+				start_time = null;
+			}
 		}
-			},
-			freeze: true,
-			freeze_message: 'Loading Task List'
-		});
 
+		if (start_time) {
+			const formatted_time = frappe.datetime.str_to_user(start_time);
+			$(this).text(formatted_time);
+			body.find(`.startButton[task-id='${task_name}'][project-id='${project_name}']`).hide();
+			body.find(`.timeEntryButton[task-id='${task_name}'][project-id='${project_name}']`).show();
+		} else {
+			$(this).text("");
+			body.find(`.startButton[task-id='${task_name}'][project-id='${project_name}']`).show();
+			body.find(`.timeEntryButton[task-id='${task_name}'][project-id='${project_name}']`).hide();
+		}
+	});
+
+	body.find(".timeEntryButton").off().on("click", function () {
+		const task_name = $(this).attr("task-id");
+		const project_name = $(this).attr("project-id");
+		const assignees = $(this).attr("assignees");
+		const start_time = localStorage.getItem(`start-time-task-${task_name}-project-${project_name}`);
+		show_time_entry_dialog(page, task_name, project_name, assignees, start_time);
+	});
+
+	body.find(".documentButton").off().on("click", function () {
+		const sub_category = $(this).attr("sub-category");
+		const customer = $(this).attr("customer");
+		customer_documents(sub_category, customer);
+	});
+
+	body.find(".credentialButton").off().on("click", function () {
+		const sub_category = $(this).attr("sub-category");
+		const customer = $(this).attr("customer");
+		customer_credentials(sub_category, customer);
+	});
+
+	set_status_colors(page);
+	hide_add_assignee_button(page.fields_dict.status.get_value());
+	assignee_and_completed_by_section(page.fields_dict.status.get_value());
+	hide_start_button_without_assignees(page);
+}
+
+/**
+Displays message when no tasks found
+*/
+
+function show_no_task_found(page) {
+	$('<div class="frappe-list"></div>')
+		.appendTo(page.body)
+		.append(
+			'<div class="no-result text-muted flex justify-center align-center" style="text-align: center;"><p>No Task found with matching filters.</p></div>'
+		);
 }
 
 /*
@@ -378,11 +333,9 @@ function setup_pagination(page, total_tasks) {
 		const next_btn = $('<button class="btn btn-default">Next</button>');
 		const info_text = $(`<span style="margin: 0 15px;">Page ${page.current_page} of ${total_pages}</span>`);
 
-		// Disable buttons when needed
 		if (page.current_page === 1) prev_btn.prop('disabled', true);
 		if (page.current_page === total_pages) next_btn.prop('disabled', true);
 
-		// Pagination button click events
 		prev_btn.on('click', () => {
 			page.current_page--;
 			refresh_tasks(page);
@@ -399,176 +352,25 @@ function setup_pagination(page, total_tasks) {
 }
 
 /*
-Sets up page length selector buttons (10, 20, 50, 100, etc.)
+Sets up page length selector buttons (20, 50, 500, 2500, etc.)
 that allow users to control how many items are shown per page
 */
+
 function setup_page_length_buttons(page) {
 	$(".page-length-btn").off("click").on("click", function () {
 		$(".page-length-btn").removeClass("active");
 		$(this).addClass("active");
 
 		page.page_length = parseInt($(this).attr("data-length"));
-		page.current_page = 1; // reset to first page
+		page.current_page = 1;
 		refresh_tasks(page, true);
 	});
 }
 
-function refresh_tasks_manually(page, selectedStatus, taskName, projectName, customerName, department, subCategory, employee, employeeGroup, from_date, to_date){
-	// Clear existing tasks from the page
-  page.body.find(".frappe-list").remove();
-
-	// const selectedStatus = page.fields_dict.status.get_value();
-	// const taskName = page.fields_dict.task.get_value();
-	// const projectName = page.fields_dict.project.get_value();
-	// const customerName = page.fields_dict.customer.get_value();
-	// const department = page.fields_dict.department.get_value();
-	// const subCategory = page.fields_dict.compliance_sub_category.get_value();
-	// const employee = page.fields_dict.employee.get_value();
-	// const employeeGroup = page.fields_dict.employee_group.get_value();
-	// const from_date = page.fields_dict.from_date.get_value();
-	// const to_date = page.fields_dict.to_date.get_value();
-
-	frappe.call({
-			method: "one_compliance.one_compliance.page.task_management_tool.task_management_tool.get_task",
-			 args: { status: selectedStatus,
-				 			 task: taskName,
-							 project: projectName,
-							 customer: customerName,
-							 department: department,
-							 sub_category: subCategory,
-							 employee: employee,
-							 employee_group: employeeGroup,
-							 from_date: from_date,
-							 to_date: to_date
-							},
-			 callback: (r) => {
-				if (r.message && r.message.length>0) {
-						// Render the list of tasks to html page
-						$(frappe.render_template("task_management_tool", {task_list:r.message})).appendTo(page.body);
-
-						// Button action to add payment details
-						page.body.find(".paymentEntryButton").on("click", function () {
-							var taskId = $(this).attr("task-id");
-							var payableAmount = $(this).attr("payable-amount");
-							var modeOfPayment = $(this).attr("mode-of-payment");
-							var referenceNumber = $(this).attr("ref-num");
-							var referenceDate = $(this).attr("ref-date");
-							var userRemark = $(this).attr("remark");
-							paymentEntryDialog(taskId, payableAmount, modeOfPayment, referenceNumber, referenceDate, userRemark);
-			});
-
-						// Button action to add assignees
-						page.body.find(".addAssigneeBtn").on("click", function () {
-							var taskName = $(this).attr("task-id");
-			  showAssignEntryDialog(taskName);
-			});
-
-						// Initially hide the timesheet button
-						page.body.find(".timeEntryButton").hide();
-
-						// Button action to start the time
-						page.body.find(".startButton").on("click", function () {
-				var taskName = $(this).attr("task-id");
-				var projectName = $(this).attr("project-id");
-
-							var status = page.fields_dict.status.get_value();
-						if (status === 'completed' || status === 'hold' || status === 'cancelled') {
-							return; // If the task status is completed, hold, or cancelled, do not proceed
-						}
-
-				var currentTime = frappe.datetime.now_datetime();
-				var formattedTime = frappe.datetime.str_to_user(currentTime);
-
-							// Save start time in local storage
-						localStorage.setItem("start-time-task-" + taskName + "-project-" + projectName, currentTime);
-
-				// Find the specific "start-time" paragraph associated with the task and project
-				var startTimeParagraph = page.body.find(".start-time[task-id='" + taskName + "'][project-id='" + projectName + "']");
-				startTimeParagraph.text(formattedTime);
-
-							// Update the status of task to 'Working'
-							updateTaskStatus(page,taskName, projectName, "Working");
-
-							// Hide the button once clicked
-							$(this).hide();
-							// Show the time sheet button
-							page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show();
-				});
-
-						// Action of start-time field
-						page.body.find(".start-time").each(function () {
-						var taskName = $(this).attr("task-id");
-						var projectName = $(this).attr("project-id");
-						var startTime = localStorage.getItem("start-time-task-" + taskName + "-project-" + projectName);
-
-								// Check if a start time is retrieved from local storage
-								if (startTime) {
-								var storedDate = new Date(startTime);
-								var currentDate = new Date();
-
-										// Check if the retrieved start time belongs to the current day
-								if (storedDate.getDate() !== currentDate.getDate() || storedDate.getMonth() !== currentDate.getMonth() || storedDate.getFullYear() !== currentDate.getFullYear()) {
-									// If startTime doesn't belong to the current day, reset the values
-									localStorage.removeItem("start-time-task-" + taskName + "-project-" + projectName);
-									startTime = null;
-								}
-							}
-								// Check if a valid start time exists
-						if (startTime) {
-							var formattedTime = frappe.datetime.str_to_user(startTime);
-							$(this).text(formattedTime);
-										page.body.find(".startButton[task-id='" + taskName + "'][project-id='" + projectName + "']").hide(); // Hide the start button associated with the task and project
-								page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show(); // Show the time entry button associated with the task and project
-						}
-								else {
-										// If no valid start time exists
-										$(this).text("");
-										page.body.find(".startButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show(); // Show the start button associated with the task and project
-										page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").hide(); // Hide the time entry button associated with the task and project
-								}
-					});
-
-						// Button action to enter timesheet
-						page.body.find(".timeEntryButton").on("click", function () {
-							var taskName = $(this).attr("task-id");
-							var projectName = $(this).attr("project-id");
-							var assignees = $(this).attr("assignees");
-							// Retrieve start time from local storage
-						var startTime = localStorage.getItem("start-time-task-" + taskName + "-project-" + projectName);
-			  showTimeEntryDialog(page, taskName, projectName, assignees, startTime);
-			});
-
-						// Button action to view Customer documents
-						page.body.find(".documentButton").on("click", function () {
-							var subCategory = $(this).attr("sub-category");
-							var customer = $(this).attr("customer");
-			  cusomerDocuments(subCategory, customer);
-			});
-
-						// Button action to view Customer credentials
-						page.body.find(".credentialButton").on("click", function () {
-							var subCategory = $(this).attr("sub-category");
-							var customer = $(this).attr("customer");
-			  cusomerCredentials(subCategory, customer);
-			});
-
-						// Function to set colors to the status
-						set_status_colors();
-						// Function to hide assignee button for complated tasks
-						hide_add_assignee_button(page.fields_dict.status.get_value());
-						// Function to show assignee section or completed section based on task status
-						assignee_and_completed_by_section(page.fields_dict.status.get_value());
-				} else {
-			// If no tasks are found, append a message to the page body
-			$('<div class="frappe-list"></div>').appendTo(page.body).append('<div class="no-result text-muted flex justify-center align-center" style="text-align: center;"><p>No Task found with matching filters.</p></div>');
-		}
-			},
-			freeze: true,
-			freeze_message: 'Loading Task List'
-		});
-
-}
-
+/**
+Hides the add assignee button if the task is completed, on hold, or cancelled.
+@param {string} taskStatus - The status of the task.
+*/
 function hide_add_assignee_button(taskStatus) {
 	if (taskStatus === 'completed' || taskStatus === 'hold' || taskStatus === 'cancelled') {
 				$('.startButton').hide();
@@ -578,6 +380,11 @@ function hide_add_assignee_button(taskStatus) {
 	}
 }
 
+/**
+Toggles the visibility of the "Assignee" and "Completed By" sections
+based on the current task status.
+*/
+
 function assignee_and_completed_by_section(taskStatus) {
 	if (taskStatus === 'completed') {
 		$('.assignee-section').hide();
@@ -586,321 +393,306 @@ function assignee_and_completed_by_section(taskStatus) {
 	}
 }
 
-function paymentEntryDialog(taskId, payableAmount, modeOfPayment, referenceNumber, referenceDate, userRemark){
-	var dialog = new frappe.ui.Dialog({
+/**
+Opens a dialog for adding or updating payment information related to a specific task.
+*/
+
+function payment_entry_dialog(task_id, payable_amount, mode_of_payment, reference_number, reference_date, user_remark) {
+	const dialog = new frappe.ui.Dialog({
 		title: __("Add Payment Info"),
 		fields: [
-					{
-							label: __("Task"),
-							fieldname: "task",
-							fieldtype: 'Link',
-							options: 'Task',
-							default: taskId,
-							read_only: 1,
-					},
-					{
-							label: __("Payable Amount"),
-							fieldname: "payable_amount",
-							fieldtype: 'Currency',
-							reqd: true,
-							default: payableAmount,
-					},
-					{
-							label: __("Mode of payment"),
-							fieldname: "mode_of_payment",
-							fieldtype: 'Link',
-							options: 'Mode of Payment',
-							reqd: true,
-							default: modeOfPayment
-					},
-					{
-						fieldtype: "Column Break",
-						fieldname: "col_break_1",
-					},
-					{
-							label: __("Reference Number"),
-							fieldname: "reference_number",
-							fieldtype: 'Data',
-							default: referenceNumber
-					},
-					{
-							label: __("Reference Date"),
-							fieldname: "reference_date",
-							fieldtype: 'Date',
-							default: referenceDate
-					},
-					{
-							label: __("User remark"),
-							fieldname: "user_remark",
-							fieldtype: 'Small Text',
-							default: userRemark
-					}
+			{
+				label: __("Task"),
+				fieldname: "task",
+				fieldtype: "Link",
+				options: "Task",
+				default: task_id,
+				read_only: 1,
+			},
+			{
+				label: __("Payable Amount"),
+				fieldname: "payable_amount",
+				fieldtype: "Currency",
+				reqd: 1,
+				default: payable_amount,
+			},
+			{
+				label: __("Mode of Payment"),
+				fieldname: "mode_of_payment",
+				fieldtype: "Link",
+				options: "Mode of Payment",
+				reqd: 1,
+				default: mode_of_payment,
+			},
+			{ fieldtype: "Column Break" },
+			{
+				label: __("Reference Number"),
+				fieldname: "reference_number",
+				fieldtype: "Data",
+				default: reference_number,
+			},
+			{
+				label: __("Reference Date"),
+				fieldname: "reference_date",
+				fieldtype: "Date",
+				default: reference_date,
+			},
+			{
+				label: __("User Remark"),
+				fieldname: "user_remark",
+				fieldtype: "Small Text",
+				default: user_remark,
+			},
 		],
-		primary_action: function (values) {
-						frappe.call({
-								method: "one_compliance.one_compliance.page.task_management_tool.task_management_tool.add_payment_info",
-								args: {
-					task_id: taskId,
+		primary_action_label: __("Save"),
+		primary_action(values) {
+			frappe.call({
+				method: "one_compliance.one_compliance.page.task_management_tool.task_management_tool.add_payment_info",
+				args: {
+					task_id,
 					payable_amount: values.payable_amount,
-										mode_of_payment: values.mode_of_payment,
-										reference_number: values.reference_number,
-										reference_date: values.reference_date,
-										user_remark: values.user_remark,
+					mode_of_payment: values.mode_of_payment,
+					reference_number: values.reference_number,
+					reference_date: values.reference_date,
+					user_remark: values.user_remark,
 				},
 				callback: function (r) {
 					frappe.msgprint("Payment info added successfully!");
-										frm.reload_doc();
-				}
-						});
+					frm.reload_doc();
+				},
+				error: (r) => frappe.msgprint(__("Error adding payment info: {0}", [r.message || "Unknown error"])),
+			});
 			dialog.hide();
+
 		},
-		primary_action_label: __("Save")
 	});
 	dialog.show();
 }
 
-function showAssignEntryDialog(taskName){
-	var dialog = new frappe.ui.Dialog({
+/**
+Opens a dialog to assign one or more employees (users) to a specific task.
+*/
+
+function show_assign_entry_dialog(task_name) {
+	const dialog = new frappe.ui.Dialog({
 		title: __("Add Employees"),
 		fields: [
-						{
-								label: __("Assign To"),
-								fieldname: "assign_to",
-								fieldtype: 'MultiSelectPills',
-								get_data: function (txt) {
-									return frappe.db.get_link_options("User", txt, {
-										user_type: "System User",
-										enabled: 1,
-									});
-								},
-						}
-		],
-		primary_action: function (values) {
-						frappe.call({
-								method: "frappe.desk.form.assign_to.add",
-								args: {
-					doctype: "Task",
-					name: taskName,
-					assign_to: values.assign_to,
+			{
+				label: __("Assign To"),
+				fieldname: "assign_to",
+				fieldtype: "MultiSelectPills",
+				get_data(txt) {
+					return frappe.db.get_link_options("User", txt, {
+						user_type: "System User",
+						enabled: 1,
+					});
 				},
-				callback: function (r) {
-					frappe.msgprint("Assignment added successfully!");
-										location.reload();
-				}
-						});
+			},
+		],
+		primary_action_label: __("Add"),
+		primary_action(values) {
+			frappe.call({
+				method: "frappe.desk.form.assign_to.add",
+				args: { doctype: "Task", name: task_name, assign_to: values.assign_to },
+				callback() {
+					frappe.msgprint(__("Assignment added successfully!"));
+					location.reload();
+				},
+				error: (r) => frappe.msgprint(__("Error adding assignment: {0}", [r.message || "Unknown error"])),
+			});
 			dialog.hide();
 		},
-		primary_action_label: __("Add")
 	});
 	dialog.show();
 }
-// Function to show the dialog box for timesheet entry
-function showTimeEntryDialog(page, taskName, projectName, assignees, startTime) {
-	var assigneesList = assignees ? assignees.split(',') : [];
 
-	var status = page.fields_dict.status.get_value();
-  if (status === 'completed' | status === 'hold'| status === 'cancelled') {
-	  return;
-  }
+/**
+Shows a dialog for time entry linked to a specific task.
+*/
 
-	// Get the pre-filled from_time and to_time values
-  var fromTime = startTime
-  var toTime = frappe.datetime.now_datetime(); // Get the current date and time for the to_time field
+function show_time_entry_dialog(page, task_name, project_name, assignees, start_time) {
+	const status = page.fields_dict.status.get_value();
+	if (["completed", "hold", "cancelled"].includes(status)) return;
 
-	var dialog = new frappe.ui.Dialog({
-		title: __("Time Entry Dialog"),
+	const assignees_list = assignees ? assignees.split(",") : [];
+	const from_time = start_time;
+	const to_time = frappe.datetime.now_datetime();
+
+	const dialog = new frappe.ui.Dialog({
+		title: __("Time Entry"),
 		fields: [
-						{
-								label: __("Employee"),
-								fieldname: "employee",
-								fieldtype: 'Select',
-								options: assigneesList,
-				default: get_employee(assigneesList, function (employee) {
-					dialog.set_value("employee", employee);
-				})
-						},
+			{
+				label: __("Employee"),
+				fieldname: "employee",
+				fieldtype: "Select",
+				options: assignees_list,
+			},
 			{
 				label: __("Project"),
 				fieldname: "project",
-				fieldtype: 'Link',
-				options: 'Project',
-								default: projectName
+				fieldtype: "Link",
+				options: "Project",
+				default: project_name,
 			},
 			{
 				label: __("From Time"),
 				fieldname: "from_time",
-				fieldtype: 'Datetime',
-				reqd: true,
-								read_only: 1,
-								default: fromTime,
+				fieldtype: "Datetime",
+				reqd: 1,
+				read_only: 1,
+				default: from_time,
 			},
-						{
-							fieldtype: "Column Break",
-							fieldname: "col_break_1",
-						},
-						{
+			{ fieldtype: "Column Break" },
+			{
 				label: __("Task"),
 				fieldname: "task",
-				fieldtype: 'Link',
-				options: 'Task',
-								default: taskName
+				fieldtype: "Link",
+				options: "Task",
+				default: task_name,
 			},
-						{
+			{
 				label: __("Activity"),
 				fieldname: "activity",
-				fieldtype: 'Link',
-				reqd: true,
-								options: 'Activity Type'
+				fieldtype: "Link",
+				options: "Activity Type",
+				reqd: 1,
 			},
 			{
 				label: __("To Time"),
 				fieldname: "to_time",
-				fieldtype: 'Datetime',
-				reqd: true,
-								read_only: 1,
-								default: toTime
-			}
+				fieldtype: "Datetime",
+				reqd: 1,
+				read_only: 1,
+				default: to_time,
+			},
 		],
-		primary_action: function (values) {
-						// Clear start time from local storage upon submitting timesheet
-						localStorage.removeItem("start-time-task-" + taskName + "-project-" + projectName);
-
-						frappe.call({
-								method: "one_compliance.one_compliance.page.task_management_tool.task_management_tool.create_timesheet",
-								args: {
-										project: values.project,
-										task: values.task,
-										employee: values.employee,
-										activity: values.activity,
-										from_time: values.from_time,
-										to_time: values.to_time
-								},
-								callback: function (r) {
-										frappe.msgprint("Timesheet created successfully!");
-										// After creating timesheet show start button and hide start-time and time entry button
-										page.body.find(".start-time[task-id='" + taskName + "'][project-id='" + projectName + "']").hide();
-										page.body.find(".startButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show();
-										page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").hide();
-
-								}
-						});
-			dialog.hide();
+		primary_action_label: __("Submit"),
+		primary_action(values) {
+			localStorage.removeItem(`start-time-task-${task_name}-project-${project_name}`);
+			frappe.call({
+				method: "one_compliance.one_compliance.page.task_management_tool.task_management_tool.create_timesheet",
+				args: values,
+				callback() {
+					frappe.msgprint(__("Timesheet created successfully!"));
+					page.body.find(`.start-time[task-id='${task_name}'][project-id='${project_name}']`).hide();
+					page.body.find(`.startButton[task-id='${task_name}'][project-id='${project_name}']`).show();
+					page.body.find(`.timeEntryButton[task-id='${task_name}'][project-id='${project_name}']`).hide();
+					dialog.hide();
+				},
+				error: (r) => frappe.msgprint(__("Error creating timesheet: {0}", [r.message || "Unknown error"])),
+			});
 		},
-		primary_action_label: __("Submit")
 	});
 
-	// Show the dialog
+	get_employee(assignees_list, (emp) => emp && dialog.set_value("employee", emp));
 	dialog.show();
 }
 
-// Function to get frappe.session.user in the employee field to filter the task
-function get_employee(assigneesList, callback) {
-	if (frappe.session.user === 'Administrator') {
-			return assigneesList[0]
+/**
+Fetches the employee name for the current logged-in user.
+*/
+
+function get_employee(assignees_list, callback) {
+	if (frappe.session.user === "Administrator") {
+		callback(assignees_list[0]);
+		return;
 	}
-	else {
-			frappe.call({
-					method: "frappe.client.get_value",
-					args: {
-							doctype: "Employee",
-							filters: { "user_id": frappe.session.user },
-							fieldname: "employee_name"
-					},
-					callback: function (response) {
-							var employeeName = response.message ? response.message.employee_name : null;
-							callback(employeeName);
-					}
-			});
-	}
+
+	frappe.db.get_value("Employee", { user_id: frappe.session.user }, "employee_name")
+		.then((r) => {
+			console.log("Employee fetched:", r.message?.employee_name);
+			callback(r.message?.employee_name || null);
+		})
+		.catch((err) => {
+			console.error("Error fetching employee:", err);
+			callback(null);
+		});
 }
+
+/**
+Applies color styling and interactive icons to task cards based on their status.
+*/
 
 function set_status_colors(page) {
-		const taskElements = document.querySelectorAll('.card.task-entry');
+	page.body.find(".card.task-entry").each(function () {
+		const task_el = $(this);
+		const status_el = task_el.find("[status-span]");
+		const status = status_el.attr("status-span");
+		const project_el = task_el.find(".card-subtitle");
+		const project_color = project_el.attr("color");
 
-		taskElements.forEach(taskElement => {
-				const statusElement = taskElement.querySelector('[status-span]');
-				const status = statusElement.getAttribute('status-span');
-				const projectElement = taskElement.querySelector('.card-subtitle');
-				let projectColor = projectElement.getAttribute('color')
+		const color_map = {
+			Open: "blue",
+			Completed: "green",
+			Overdue: "red",
+			Working: "tomato",
+		};
 
-		if (status === 'Open') {
-					statusElement.style.color = 'blue';
-					showTicIcon(statusElement);
-					projectElement.style.color = 'blue';
-		} else if (status === 'Completed') {
-			statusElement.style.color = 'green';
-						projectElement.style.color = 'green';
-		} else if (status === 'Overdue') {
-			statusElement.style.color = 'red';
-						showTicIcon(statusElement);
-						projectElement.style.color = 'red';
-		} else if (status === 'Working') {
-			statusElement.style.color = 'tomato';
-						showTicIcon(statusElement);
-						projectElement.style.color = 'tomato';
-		}
+		const color = color_map[status] || project_color;
+		status_el.css("color", color);
+		project_el.css("color", color);
 
-				if (projectColor) {
-				projectElement.style.color = projectColor;
-			}
+		if (["Open", "Overdue", "Working"].includes(status)) add_check_icon(status_el[0]);
 	});
-		// Show tic icon for status updation.
-		function showTicIcon(element) {
-			if (!element.querySelector('.fa-check-circle')) {
-		const ticIcon = document.createElement('i');
-		ticIcon.className = 'fas fa-check-circle';
-		ticIcon.style.color = 'green';
-		ticIcon.style.cursor = 'pointer';
-				ticIcon.title = 'Update Status';
 
-		element.appendChild(document.createTextNode(' '));
-		element.appendChild(ticIcon);
+	function add_check_icon(element) {
+		if (element.querySelector(".fa-check-circle")) return;
+		const icon = document.createElement("i");
+		icon.className = "fas fa-check-circle";
+		icon.style.color = "green";
+		icon.style.cursor = "pointer";
+		icon.title = __("Update Status");
 
-		const taskName = element.getAttribute('task-name');
-		const taskId = element.getAttribute('task-id');
-		const projectId = element.getAttribute('project-id');
-				// Status updation to completed action for tic icon
-		ticIcon.addEventListener('click', function () {
-			update_status(page, taskName, projectId, taskId);
+		element.append(" ", icon);
+
+		icon.addEventListener("click", () => {
+			const task_name = element.getAttribute("task-name");
+			const task_id = element.getAttribute("task-id");
+			const project_id = element.getAttribute("project-id");
+			update_status(page, task_name, project_id, task_id);
 		});
-			}
 	}
 }
 
-function cusomerDocuments(subCategory, customer) {
+/**
+Opens a dialog displaying a customer's document details for a specific compliance sub-category.
+*/
+
+function customer_documents(sub_category, customer) {
 	frappe.call({
-		method:'one_compliance.one_compliance.utils.view_customer_documents',
-		args:{
-			'customer': customer,
-			'compliance_sub_category': subCategory
+		method: "one_compliance.one_compliance.utils.view_customer_documents",
+		args: { customer, compliance_sub_category: sub_category },
+		callback(r) {
+			if (r.message?.length) {
+				const d = new frappe.ui.Dialog({
+					title: __("Document Details"),
+					fields: [
+						{
+							label: __("Document Attachment"),
+							fieldname: "document_attachment",
+							fieldtype: "Data",
+							read_only: 1,
+							default: r.message[0],
+						},
+					],
+					primary_action_label: __("Download"),
+					primary_action() {
+						window.open(r.message[0]);
+					},
+				});
+				d.show();
+			}
 		},
-		callback:function(r){
-			if (r.message){
-					var newd = new frappe.ui.Dialog({
-						 title: 'Document details',
-						 fields: [
-							 {
-								 label: 'Document Attachment',
-								 fieldname: 'document_attachment',
-								 fieldtype: 'Data',
-								 read_only: 1,
-								 default:r.message[0]
-							 },
-						 ],
-						 primary_action_label : 'Download',
-						 primary_action(value){
-							 window.open(r.message[0])
-						 }
-					 });
-					 newd.show();
-				 }
-			 }
-	 });
+	});
 }
 
-function cusomerCredentials(subCategory, customer){
-	let d = new frappe.ui.Dialog({
-		title: 'Enter details',
+/**
+Displays and retrieves customer credential details for a specific compliance sub-category.
+*/
+
+function customer_credentials(sub_category, customer) {
+	const dialog = new frappe.ui.Dialog({
+		title: __("Enter Details"),
 		fields: [
 			{
 				label: 'Purpose',
@@ -911,7 +703,7 @@ function cusomerCredentials(subCategory, customer){
 				get_query: function () {
 					return {
 						filters: {
-							'compliance_sub_category': subCategory
+							'compliance_sub_category': sub_category
 						}
 					};
 				}
@@ -924,133 +716,134 @@ function cusomerCredentials(subCategory, customer){
 				return;
 			}
 			frappe.call({
-				method:'one_compliance.one_compliance.utils.view_credential_details',
-				args:{
+				method: 'one_compliance.one_compliance.utils.view_credential_details',
+				args: {
 					'customer': customer,
 					'purpose': values.purpose
 				},
-				callback:function(r){
-					if (r.message){
-						d.hide();
-						let newd = new frappe.ui.Dialog({
-							title: 'Credential details',
+				callback(r) {
+					if (r.message?.length >= 3) {
+						dialog.hide();
+						const details = new frappe.ui.Dialog({
+							title: __("Credential Details"),
 							fields: [
-								{
-									label: 'Username',
-									fieldname: 'username',
-									fieldtype: 'Data',
-									read_only: 1,
-									default:r.message[0]
-								},
-								{
-									label: 'Password',
-									fieldame: 'password',
-									fieldtype: 'Data',
-									read_only: 1,
-									default:r.message[1]
-								},
-								{
-									label: 'Url',
-									fieldname: 'url',
-									fieldtype: 'Data',
-									options: 'URL',
-									read_only: 1,
-									default:r.message[2]
-								 }
-								],
-								 primary_action_label: 'Close',
-								 primary_action(value) {
-									 newd.hide();
-								 },
-								 secondary_action_label : 'Go To URL',
-								 secondary_action(value){
-									 window.open(r.message[2])
-								 }
-							 });
-							 newd.show();
-						 }
-					 }
-				 })
-			 }
-		 });
-		 d.show();
-}
-
-function update_status(page, taskName, projectId, taskId) {
-	let fields = [
-		{
-			label: 'Status',
-			fieldname: 'status',
-			fieldtype: 'Select',
-			options: 'Open\nWorking\nPending Review\nCompleted\nHold',
-			default: 'Completed'
-		},
-		{
-			label: 'Completed By',
-			fieldname: 'completed_by',
-			fieldtype: 'Link',
-			options: 'User'
-		},
-		{
-			label: 'Completed On',
-			fieldname: 'completed_on',
-			fieldtype: 'Date',
-			default: 'Today'
-		}
-	];
-
-	let d = new frappe.ui.Dialog({
-		title: 'Enter details',
-		fields: fields,
-		primary_action_label: 'Update',
-		primary_action(values) {
-			frappe.call({
-			method: 'one_compliance.one_compliance.doc_events.task.update_task_status',
-			args: {
-			  'task_id': taskId,
-			  'status': values.status,
-			  'completed_by': values.completed_by,
-			  'completed_on': values.completed_on
-			},
-			callback: function(r){
-			  if (r.message){
-				d.hide();
-						const selectedStatus = page.fields_dict.status.get_value();
-						const taskName = page.fields_dict.task.get_value();
-						const projectName = page.fields_dict.project.get_value();
-						const customerName = page.fields_dict.customer.get_value();
-						const department = page.fields_dict.department.get_value();
-						const subCategory = page.fields_dict.compliance_sub_category.get_value();
-						const employee = page.fields_dict.employee.get_value();
-						const employeeGroup = page.fields_dict.employee_group.get_value();
-						const from_date = page.fields_dict.from_date.get_value();
-						const to_date = page.fields_dict.to_date.get_value();
-						refresh_tasks_manually(page, selectedStatus, taskName, projectName, customerName, department, subCategory, employee, employeeGroup, from_date, to_date)
-						// location.reload();
-			  }
-			}
-		  });
+								{ label: __("Username"), fieldname: "username", fieldtype: "Data", read_only: 1, default: r.message[0] },
+								{ label: __("Password"), fieldname: "password", fieldtype: "Data", read_only: 1, default: r.message[1] },
+								{ label: __("URL"), fieldname: "url", fieldtype: "Data", read_only: 1, default: r.message[2] },
+							],
+							primary_action_label: __("Close"),
+							primary_action() { details.hide(); },
+							secondary_action_label: __("Go To URL"),
+							secondary_action() { window.open(r.message[2]); },
+						});
+						details.show();
+					}
+				},
+			});
 		},
 	});
-	d.set_value('completed_by', frappe.session.user);
-d.show();
+	dialog.show();
 }
 
-// Function to update status to working when clicking start time
-function updateTaskStatus(page, taskName, projectName, status){
-	frappe.call({
-			method: "one_compliance.one_compliance.page.task_management_tool.task_management_tool.update_task_status", // Change this to your method name
-			args: {
-					task: taskName,
-					project: projectName,
-					status: status
+/**
+Opens a dialog to update the status of a specific task and refreshes the task list upon completion.
+*/
+
+function update_status(page, task_name, project_id, task_id) {
+	const dialog = new frappe.ui.Dialog({
+		title: __("Update Task Status"),
+		fields: [
+			{
+				label: __("Status"),
+				fieldname: "status",
+				fieldtype: "Select",
+				options: "Open\nWorking\nPending Review\nCompleted\nHold",
+				default: "Completed",
 			},
-			callback: function (response) {
-					if (response.message === "success") {
-							page.fields_dict.status.set_value("working");
-					} else {
-							console.log("Failed to update task status");
+			{
+				label: __("Completed By"),
+				fieldname: "completed_by",
+				fieldtype: "Link",
+				options: "User",
+				default: frappe.session.user,
+			},
+			{
+				label: __("Completed On"),
+				fieldname: "completed_on",
+				fieldtype: "Date",
+				default: frappe.datetime.get_today(),
+			},
+		],
+		primary_action_label: __("Update"),
+		primary_action(values) {
+			frappe.call({
+				method: "one_compliance.one_compliance.doc_events.task.update_task_status",
+				args: { task_id, ...values },
+				callback(r) {
+					if (r.message) {
+						dialog.hide();
+						const f = page.fields_dict;
+						refresh_tasks_manually(
+							page,
+							f.status.get_value(),
+							f.task.get_value(),
+							f.project.get_value(),
+							f.customer.get_value(),
+							f.department.get_value(),
+							f.compliance_sub_category.get_value(),
+							f.employee.get_value(),
+							f.employee_group.get_value(),
+							f.from_date.get_value(),
+							f.to_date.get_value()
+						);
 					}
+				},
+			});
+		},
+	});
+	dialog.show();
+}
+
+/**
+Updates the task status to "Working" when start time is clicked.
+*/
+
+function update_task_status(page, task_name, project_name, status) {
+	frappe.call({
+		method: "one_compliance.one_compliance.page.task_management_tool.task_management_tool.update_task_status",
+		args: { task: task_name, project: project_name, status },
+		callback(r) {
+			if (r.message === "success") {
+				page.fields_dict.status.set_value("working");
+			} else {
+				console.warn("Failed to update task status");
 			}
+		},
+	});
+}
+
+/**
+Hide start buttons if no assignees are set OR if task already has a start time.
+*/
+
+function hide_start_button_without_assignees(page) {
+	if (!page || !page.body) return;
+
+	page.body.find(".startButton").each(function () {
+		const $btn = $(this);
+		let assignees = $btn.attr("assignees") || "";
+		const task_id = $btn.attr("task-id");
+		const project_id = $btn.attr("project-id");
+
+		assignees = assignees.replace(/\s+/g, "").trim();
+
+		const start_time_key = "start-time-task-" + task_id + "-project-" + project_id;
+		const start_time = localStorage.getItem(start_time_key);
+
+		if (!assignees || start_time) {
+			$btn.hide();
+		} else {
+			$btn.show();
+		}
 	});
 }

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
@@ -1,30 +1,33 @@
 frappe.pages['task-management-tool'].on_page_load = function (wrapper) {
-    var page = frappe.ui.make_app_page({
-        parent: wrapper,
-        title: 'Task Management Tool',
-        single_column: true
-    });
+	var page = frappe.ui.make_app_page({
+		parent: wrapper,
+		title: 'Task Management Tool',
+		single_column: true
+	});
 
-    page.main.addClass("frappe-card");
+	page.main.addClass("frappe-card");
 
-    make_filters(page);
-    if (!frappe.route_options || !frappe.route_options.project) {
-        refresh_tasks(page);
-    }
+	page.current_page = 1;
+	page.page_length = 20;
+
+	make_filters(page);
+	if (!frappe.route_options || !frappe.route_options.project) {
+		refresh_tasks(page, true);
+	}
 }
 
 frappe.pages['task-management-tool'].on_page_show = function (wrapper) {
-    var page = wrapper.page;
-    
-    if (frappe.route_options && frappe.route_options.project) {
-        page.fields_dict.project.set_value(frappe.route_options.project);
-        
-        frappe.route_options = null;
-        
-        setTimeout(() => {
-            refresh_tasks(page);
-        }, 500);
-    }
+	var page = wrapper.page;
+	
+	if (frappe.route_options && frappe.route_options.project) {
+		page.fields_dict.project.set_value(frappe.route_options.project);
+		
+		frappe.route_options = null;
+		
+		setTimeout(() => {
+			refresh_tasks(page);
+		}, 500);
+	}
 }
 
 function make_filters(page) {
@@ -36,8 +39,8 @@ function make_filters(page) {
 		options: "Task",
 		change() {
 			if (page.fields_dict.task.get_value()) {
-          refresh_tasks(page);
-      }
+		  refresh_tasks(page);
+	  }
 		}
 	});
 	page.fields_dict.task.$input.on('change', function() {
@@ -53,8 +56,8 @@ function make_filters(page) {
 		default:project_id,
 		change() {
 			if (page.fields_dict.project.get_value()) {
-          refresh_tasks(page);
-      }
+		  refresh_tasks(page);
+	  }
 		}
 	});
 	localStorage.removeItem('selected_project_id');
@@ -70,8 +73,8 @@ function make_filters(page) {
 		options:"Customer",
 		change() {
 			if (page.fields_dict.customer.get_value()) {
-          refresh_tasks(page);
-      }
+		  refresh_tasks(page);
+	  }
 		}
 	});
 	page.fields_dict.customer.$input.on('change', function() {
@@ -87,8 +90,8 @@ function make_filters(page) {
 		default: get_employee_id(),
 		change() {
 			if (page.fields_dict.employee.get_value()) {
-          refresh_tasks(page);
-      }
+		  refresh_tasks(page);
+	  }
 		},
 		read_only: frappe.session.user === 'Administrator' ? 0 : 1
 	});
@@ -104,8 +107,8 @@ function make_filters(page) {
 		options: "Employee Group",
 		change() {
 			if (page.fields_dict.employee_group.get_value()) {
-          refresh_tasks(page);
-      }
+		  refresh_tasks(page);
+	  }
 		}
 	});
 	page.fields_dict.employee_group.$input.on('change', function() {
@@ -120,8 +123,8 @@ function make_filters(page) {
 		options: "Department",
 		change() {
 			if (page.fields_dict.department.get_value()) {
-          refresh_tasks(page);
-      }
+		  refresh_tasks(page);
+	  }
 		}
 	});
 	page.fields_dict.department.$input.on('change', function() {
@@ -136,8 +139,8 @@ function make_filters(page) {
 		options: "Compliance Sub Category",
 		change() {
 			if (page.fields_dict.compliance_sub_category.get_value()) {
-          refresh_tasks(page);
-      }
+		  refresh_tasks(page);
+	  }
 		}
 	});
 	page.fields_dict.compliance_sub_category.$input.on('change', function() {
@@ -151,15 +154,15 @@ function make_filters(page) {
 		fieldtype: "Date"
 	});
 	page.fields_dict.from_date.$input.off('change').on('change', function() {
-        refresh_tasks(page);
-    });
+		refresh_tasks(page);
+	});
 	let toDateField = page.add_field({
 		label: __("To Date"),
 		fieldname: "to_date",
 		fieldtype: "Date"
 	});
 	page.fields_dict.to_date.$input.off('change').on('change', function() {
-      refresh_tasks(page);
+	  refresh_tasks(page);
   });
 	let status = page.add_field({
 		label: __("Status"),
@@ -183,17 +186,22 @@ function make_filters(page) {
 }
 
 function get_employee_id() {
-    if (frappe.session.user === 'Administrator') {
-        return '';
-    }
+	if (frappe.session.user === 'Administrator') {
+		return '';
+	}
 		else {
 				return frappe.session.user
 		}
 }
 
-function refresh_tasks(page){
-	// Clear existing tasks from the page
-  page.body.find(".frappe-list").remove();
+function refresh_tasks(page, reset_page = false) {
+	if (reset_page) {
+		page.current_page = 1;
+	}
+
+	// Clear existing tasks and pagination from the page
+	page.body.find(".frappe-list").remove();
+	page.body.find(".pagination-container").remove();
 
 	const selectedStatus = page.fields_dict.status.get_value();
 	const taskName = page.fields_dict.task.get_value();
@@ -207,25 +215,31 @@ function refresh_tasks(page){
 	const to_date = page.fields_dict.to_date.get_value();
 
 	frappe.call({
-			method: "one_compliance.one_compliance.page.task_management_tool.task_management_tool.get_task",
-			 args: { status: selectedStatus,
-				 			 task: taskName,
-							 project: projectName,
-							 customer: customerName,
-							 department: department,
-							 sub_category: subCategory,
-							 employee: employee,
-							 employee_group: employeeGroup,
-							 from_date: from_date,
-							 to_date: to_date
-							},
-			 callback: (r) => {
-				if (r.message && r.message.length>0) {
-						// Render the list of tasks to html page
-						$(frappe.render_template("task_management_tool", {task_list:r.message})).appendTo(page.body);
+		method: "one_compliance.one_compliance.page.task_management_tool.task_management_tool.get_task",
+		args: {
+			status: selectedStatus,
+			task: taskName,
+			project: projectName,
+			customer: customerName,
+			department: department,
+			sub_category: subCategory,
+			employee: employee,
+			employee_group: employeeGroup,
+			from_date: from_date,
+			to_date: to_date,
+			page: page.current_page,
+			page_length: page.page_length
+		},
+		callback: (r) => {
+			if (r.message && r.message.tasks.length > 0) {
+				// Render the list of tasks to html page
+				$(frappe.render_template("task_management_tool", { task_list: r.message.tasks })).appendTo(page.body);
+				setup_pagination(page, r.message.total_tasks);
+                setup_page_length_buttons(page);
 
-						// Button action to add payment details
-						page.body.find(".paymentEntryButton").on("click", function () {
+
+				// Button action to add payment details
+				page.body.find(".paymentEntryButton").on("click", function () {
 							var taskId = $(this).attr("task-id");
 							var payableAmount = $(this).attr("payable-amount");
 							var modeOfPayment = $(this).attr("mode-of-payment");
@@ -233,36 +247,36 @@ function refresh_tasks(page){
 							var referenceDate = $(this).attr("ref-date");
 							var userRemark = $(this).attr("remark");
 							paymentEntryDialog(taskId, payableAmount, modeOfPayment, referenceNumber, referenceDate, userRemark);
-            });
+			});
 
 						// Button action to add assignees
 						page.body.find(".addAssigneeBtn").on("click", function () {
 							var taskName = $(this).attr("task-id");
-              showAssignEntryDialog(taskName);
-            });
+			  showAssignEntryDialog(taskName);
+			});
 
 						// Initially hide the timesheet button
 						page.body.find(".timeEntryButton").hide();
 
 						// Button action to start the time
 						page.body.find(".startButton").on("click", function () {
-	            var taskName = $(this).attr("task-id");
-	            var projectName = $(this).attr("project-id");
+				var taskName = $(this).attr("task-id");
+				var projectName = $(this).attr("project-id");
 
 							var status = page.fields_dict.status.get_value();
-					    if (status === 'completed' || status === 'hold' || status === 'cancelled') {
-					        return; // If the task status is completed, hold, or cancelled, do not proceed
-					    }
+						if (status === 'completed' || status === 'hold' || status === 'cancelled') {
+							return; // If the task status is completed, hold, or cancelled, do not proceed
+						}
 
-	            var currentTime = frappe.datetime.now_datetime();
-	            var formattedTime = frappe.datetime.str_to_user(currentTime);
+				var currentTime = frappe.datetime.now_datetime();
+				var formattedTime = frappe.datetime.str_to_user(currentTime);
 
 							// Save start time in local storage
-    					localStorage.setItem("start-time-task-" + taskName + "-project-" + projectName, currentTime);
+						localStorage.setItem("start-time-task-" + taskName + "-project-" + projectName, currentTime);
 
-	            // Find the specific "start-time" paragraph associated with the task and project
-	            var startTimeParagraph = page.body.find(".start-time[task-id='" + taskName + "'][project-id='" + projectName + "']");
-	            startTimeParagraph.text(formattedTime);
+				// Find the specific "start-time" paragraph associated with the task and project
+				var startTimeParagraph = page.body.find(".start-time[task-id='" + taskName + "'][project-id='" + projectName + "']");
+				startTimeParagraph.text(formattedTime);
 
 							// Update the status of task to 'Working'
 							updateTaskStatus(page,taskName, projectName, "Working");
@@ -271,40 +285,40 @@ function refresh_tasks(page){
 							$(this).hide();
 							// Show the time sheet button
 							page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show();
-		        });
+				});
 
 						// Action of start-time field
 						page.body.find(".start-time").each(function () {
-				        var taskName = $(this).attr("task-id");
-				        var projectName = $(this).attr("project-id");
-				        var startTime = localStorage.getItem("start-time-task-" + taskName + "-project-" + projectName);
+						var taskName = $(this).attr("task-id");
+						var projectName = $(this).attr("project-id");
+						var startTime = localStorage.getItem("start-time-task-" + taskName + "-project-" + projectName);
 
 								// Check if a start time is retrieved from local storage
 								if (startTime) {
-						        var storedDate = new Date(startTime);
-						        var currentDate = new Date();
+								var storedDate = new Date(startTime);
+								var currentDate = new Date();
 
 										// Check if the retrieved start time belongs to the current day
-						        if (storedDate.getDate() !== currentDate.getDate() || storedDate.getMonth() !== currentDate.getMonth() || storedDate.getFullYear() !== currentDate.getFullYear()) {
-						            // If startTime doesn't belong to the current day, reset the values
-						            localStorage.removeItem("start-time-task-" + taskName + "-project-" + projectName);
-						            startTime = null;
-						        }
-						    }
+								if (storedDate.getDate() !== currentDate.getDate() || storedDate.getMonth() !== currentDate.getMonth() || storedDate.getFullYear() !== currentDate.getFullYear()) {
+									// If startTime doesn't belong to the current day, reset the values
+									localStorage.removeItem("start-time-task-" + taskName + "-project-" + projectName);
+									startTime = null;
+								}
+							}
 								// Check if a valid start time exists
-				        if (startTime) {
-				            var formattedTime = frappe.datetime.str_to_user(startTime);
-				            $(this).text(formattedTime);
+						if (startTime) {
+							var formattedTime = frappe.datetime.str_to_user(startTime);
+							$(this).text(formattedTime);
 										page.body.find(".startButton[task-id='" + taskName + "'][project-id='" + projectName + "']").hide(); // Hide the start button associated with the task and project
-        						page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show(); // Show the time entry button associated with the task and project
-				        }
+								page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show(); // Show the time entry button associated with the task and project
+						}
 								else {
 										// If no valid start time exists
 										$(this).text("");
 										page.body.find(".startButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show(); // Show the start button associated with the task and project
 										page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").hide(); // Hide the time entry button associated with the task and project
 								}
-				    });
+					});
 
 						// Button action to enter timesheet
 						page.body.find(".timeEntryButton").on("click", function () {
@@ -312,23 +326,23 @@ function refresh_tasks(page){
 							var projectName = $(this).attr("project-id");
 							var assignees = $(this).attr("assignees");
 							// Retrieve start time from local storage
-    					var startTime = localStorage.getItem("start-time-task-" + taskName + "-project-" + projectName);
-              showTimeEntryDialog(page, taskName, projectName, assignees, startTime);
-            });
+						var startTime = localStorage.getItem("start-time-task-" + taskName + "-project-" + projectName);
+			  showTimeEntryDialog(page, taskName, projectName, assignees, startTime);
+			});
 
 						// Button action to view Customer documents
 						page.body.find(".documentButton").on("click", function () {
 							var subCategory = $(this).attr("sub-category");
 							var customer = $(this).attr("customer");
-              cusomerDocuments(subCategory, customer);
-            });
+			  cusomerDocuments(subCategory, customer);
+			});
 
 						// Button action to view Customer credentials
 						page.body.find(".credentialButton").on("click", function () {
 							var subCategory = $(this).attr("sub-category");
 							var customer = $(this).attr("customer");
-              cusomerCredentials(subCategory, customer);
-            });
+			  cusomerCredentials(subCategory, customer);
+			});
 
 						// Function to set colors to the status
 						set_status_colors(page);
@@ -337,14 +351,66 @@ function refresh_tasks(page){
 						// Function to show assignee section or completed section based on task status
 						assignee_and_completed_by_section(page.fields_dict.status.get_value());
 				} else {
-            // If no tasks are found, append a message to the page body
-            $('<div class="frappe-list"></div>').appendTo(page.body).append('<div class="no-result text-muted flex justify-center align-center" style="text-align: center;"><p>No Task found with matching filters.</p></div>');
-        }
+			// If no tasks are found, append a message to the page body
+			$('<div class="frappe-list"></div>').appendTo(page.body).append('<div class="no-result text-muted flex justify-center align-center" style="text-align: center;"><p>No Task found with matching filters.</p></div>');
+		}
 			},
 			freeze: true,
 			freeze_message: 'Loading Task List'
 		});
 
+}
+
+/*
+Sets up pagination controls (Previous, Next, and Page Info)
+inside the #pagination-container element.
+*/
+
+function setup_pagination(page, total_tasks) {
+	const container = page.body.find("#pagination-container");
+	container.empty();
+
+	const total_pages = Math.ceil(total_tasks / page.page_length);
+
+	if (total_pages > 1) {
+		const pagination_controls = $('<div class="pagination-controls"></div>');
+		const prev_btn = $('<button class="btn btn-default">Previous</button>');
+		const next_btn = $('<button class="btn btn-default">Next</button>');
+		const info_text = $(`<span style="margin: 0 15px;">Page ${page.current_page} of ${total_pages}</span>`);
+
+		// Disable buttons when needed
+		if (page.current_page === 1) prev_btn.prop('disabled', true);
+		if (page.current_page === total_pages) next_btn.prop('disabled', true);
+
+		// Pagination button click events
+		prev_btn.on('click', () => {
+			page.current_page--;
+			refresh_tasks(page);
+		});
+
+		next_btn.on('click', () => {
+			page.current_page++;
+			refresh_tasks(page);
+		});
+
+		pagination_controls.append(prev_btn, info_text, next_btn);
+		container.append(pagination_controls);
+	}
+}
+
+/*
+Sets up page length selector buttons (10, 20, 50, 100, etc.)
+that allow users to control how many items are shown per page
+*/
+function setup_page_length_buttons(page) {
+	$(".page-length-btn").off("click").on("click", function () {
+		$(".page-length-btn").removeClass("active");
+		$(this).addClass("active");
+
+		page.page_length = parseInt($(this).attr("data-length"));
+		page.current_page = 1; // reset to first page
+		refresh_tasks(page, true);
+	});
 }
 
 function refresh_tasks_manually(page, selectedStatus, taskName, projectName, customerName, department, subCategory, employee, employeeGroup, from_date, to_date){
@@ -389,36 +455,36 @@ function refresh_tasks_manually(page, selectedStatus, taskName, projectName, cus
 							var referenceDate = $(this).attr("ref-date");
 							var userRemark = $(this).attr("remark");
 							paymentEntryDialog(taskId, payableAmount, modeOfPayment, referenceNumber, referenceDate, userRemark);
-            });
+			});
 
 						// Button action to add assignees
 						page.body.find(".addAssigneeBtn").on("click", function () {
 							var taskName = $(this).attr("task-id");
-              showAssignEntryDialog(taskName);
-            });
+			  showAssignEntryDialog(taskName);
+			});
 
 						// Initially hide the timesheet button
 						page.body.find(".timeEntryButton").hide();
 
 						// Button action to start the time
 						page.body.find(".startButton").on("click", function () {
-	            var taskName = $(this).attr("task-id");
-	            var projectName = $(this).attr("project-id");
+				var taskName = $(this).attr("task-id");
+				var projectName = $(this).attr("project-id");
 
 							var status = page.fields_dict.status.get_value();
-					    if (status === 'completed' || status === 'hold' || status === 'cancelled') {
-					        return; // If the task status is completed, hold, or cancelled, do not proceed
-					    }
+						if (status === 'completed' || status === 'hold' || status === 'cancelled') {
+							return; // If the task status is completed, hold, or cancelled, do not proceed
+						}
 
-	            var currentTime = frappe.datetime.now_datetime();
-	            var formattedTime = frappe.datetime.str_to_user(currentTime);
+				var currentTime = frappe.datetime.now_datetime();
+				var formattedTime = frappe.datetime.str_to_user(currentTime);
 
 							// Save start time in local storage
-    					localStorage.setItem("start-time-task-" + taskName + "-project-" + projectName, currentTime);
+						localStorage.setItem("start-time-task-" + taskName + "-project-" + projectName, currentTime);
 
-	            // Find the specific "start-time" paragraph associated with the task and project
-	            var startTimeParagraph = page.body.find(".start-time[task-id='" + taskName + "'][project-id='" + projectName + "']");
-	            startTimeParagraph.text(formattedTime);
+				// Find the specific "start-time" paragraph associated with the task and project
+				var startTimeParagraph = page.body.find(".start-time[task-id='" + taskName + "'][project-id='" + projectName + "']");
+				startTimeParagraph.text(formattedTime);
 
 							// Update the status of task to 'Working'
 							updateTaskStatus(page,taskName, projectName, "Working");
@@ -427,40 +493,40 @@ function refresh_tasks_manually(page, selectedStatus, taskName, projectName, cus
 							$(this).hide();
 							// Show the time sheet button
 							page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show();
-		        });
+				});
 
 						// Action of start-time field
 						page.body.find(".start-time").each(function () {
-				        var taskName = $(this).attr("task-id");
-				        var projectName = $(this).attr("project-id");
-				        var startTime = localStorage.getItem("start-time-task-" + taskName + "-project-" + projectName);
+						var taskName = $(this).attr("task-id");
+						var projectName = $(this).attr("project-id");
+						var startTime = localStorage.getItem("start-time-task-" + taskName + "-project-" + projectName);
 
 								// Check if a start time is retrieved from local storage
 								if (startTime) {
-						        var storedDate = new Date(startTime);
-						        var currentDate = new Date();
+								var storedDate = new Date(startTime);
+								var currentDate = new Date();
 
 										// Check if the retrieved start time belongs to the current day
-						        if (storedDate.getDate() !== currentDate.getDate() || storedDate.getMonth() !== currentDate.getMonth() || storedDate.getFullYear() !== currentDate.getFullYear()) {
-						            // If startTime doesn't belong to the current day, reset the values
-						            localStorage.removeItem("start-time-task-" + taskName + "-project-" + projectName);
-						            startTime = null;
-						        }
-						    }
+								if (storedDate.getDate() !== currentDate.getDate() || storedDate.getMonth() !== currentDate.getMonth() || storedDate.getFullYear() !== currentDate.getFullYear()) {
+									// If startTime doesn't belong to the current day, reset the values
+									localStorage.removeItem("start-time-task-" + taskName + "-project-" + projectName);
+									startTime = null;
+								}
+							}
 								// Check if a valid start time exists
-				        if (startTime) {
-				            var formattedTime = frappe.datetime.str_to_user(startTime);
-				            $(this).text(formattedTime);
+						if (startTime) {
+							var formattedTime = frappe.datetime.str_to_user(startTime);
+							$(this).text(formattedTime);
 										page.body.find(".startButton[task-id='" + taskName + "'][project-id='" + projectName + "']").hide(); // Hide the start button associated with the task and project
-        						page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show(); // Show the time entry button associated with the task and project
-				        }
+								page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show(); // Show the time entry button associated with the task and project
+						}
 								else {
 										// If no valid start time exists
 										$(this).text("");
 										page.body.find(".startButton[task-id='" + taskName + "'][project-id='" + projectName + "']").show(); // Show the start button associated with the task and project
 										page.body.find(".timeEntryButton[task-id='" + taskName + "'][project-id='" + projectName + "']").hide(); // Hide the time entry button associated with the task and project
 								}
-				    });
+					});
 
 						// Button action to enter timesheet
 						page.body.find(".timeEntryButton").on("click", function () {
@@ -468,23 +534,23 @@ function refresh_tasks_manually(page, selectedStatus, taskName, projectName, cus
 							var projectName = $(this).attr("project-id");
 							var assignees = $(this).attr("assignees");
 							// Retrieve start time from local storage
-    					var startTime = localStorage.getItem("start-time-task-" + taskName + "-project-" + projectName);
-              showTimeEntryDialog(page, taskName, projectName, assignees, startTime);
-            });
+						var startTime = localStorage.getItem("start-time-task-" + taskName + "-project-" + projectName);
+			  showTimeEntryDialog(page, taskName, projectName, assignees, startTime);
+			});
 
 						// Button action to view Customer documents
 						page.body.find(".documentButton").on("click", function () {
 							var subCategory = $(this).attr("sub-category");
 							var customer = $(this).attr("customer");
-              cusomerDocuments(subCategory, customer);
-            });
+			  cusomerDocuments(subCategory, customer);
+			});
 
 						// Button action to view Customer credentials
 						page.body.find(".credentialButton").on("click", function () {
 							var subCategory = $(this).attr("sub-category");
 							var customer = $(this).attr("customer");
-              cusomerCredentials(subCategory, customer);
-            });
+			  cusomerCredentials(subCategory, customer);
+			});
 
 						// Function to set colors to the status
 						set_status_colors();
@@ -493,9 +559,9 @@ function refresh_tasks_manually(page, selectedStatus, taskName, projectName, cus
 						// Function to show assignee section or completed section based on task status
 						assignee_and_completed_by_section(page.fields_dict.status.get_value());
 				} else {
-            // If no tasks are found, append a message to the page body
-            $('<div class="frappe-list"></div>').appendTo(page.body).append('<div class="no-result text-muted flex justify-center align-center" style="text-align: center;"><p>No Task found with matching filters.</p></div>');
-        }
+			// If no tasks are found, append a message to the page body
+			$('<div class="frappe-list"></div>').appendTo(page.body).append('<div class="no-result text-muted flex justify-center align-center" style="text-align: center;"><p>No Task found with matching filters.</p></div>');
+		}
 			},
 			freeze: true,
 			freeze_message: 'Loading Task List'
@@ -504,26 +570,26 @@ function refresh_tasks_manually(page, selectedStatus, taskName, projectName, cus
 }
 
 function hide_add_assignee_button(taskStatus) {
-    if (taskStatus === 'completed' || taskStatus === 'hold' || taskStatus === 'cancelled') {
+	if (taskStatus === 'completed' || taskStatus === 'hold' || taskStatus === 'cancelled') {
 				$('.startButton').hide();
-        $('.addAssigneeBtn').hide();
-    } else {
-        $('.addAssigneeBtn').show();
-    }
+		$('.addAssigneeBtn').hide();
+	} else {
+		$('.addAssigneeBtn').show();
+	}
 }
 
 function assignee_and_completed_by_section(taskStatus) {
-    if (taskStatus === 'completed') {
-        $('.assignee-section').hide();
-    } else {
-        $('.completed-by-section').hide();
-    }
+	if (taskStatus === 'completed') {
+		$('.assignee-section').hide();
+	} else {
+		$('.completed-by-section').hide();
+	}
 }
 
 function paymentEntryDialog(taskId, payableAmount, modeOfPayment, referenceNumber, referenceDate, userRemark){
 	var dialog = new frappe.ui.Dialog({
-        title: __("Add Payment Info"),
-        fields: [
+		title: __("Add Payment Info"),
+		fields: [
 					{
 							label: __("Task"),
 							fieldname: "task",
@@ -569,34 +635,34 @@ function paymentEntryDialog(taskId, payableAmount, modeOfPayment, referenceNumbe
 							fieldtype: 'Small Text',
 							default: userRemark
 					}
-        ],
-        primary_action: function (values) {
+		],
+		primary_action: function (values) {
 						frappe.call({
 								method: "one_compliance.one_compliance.page.task_management_tool.task_management_tool.add_payment_info",
 								args: {
-                    task_id: taskId,
-                    payable_amount: values.payable_amount,
+					task_id: taskId,
+					payable_amount: values.payable_amount,
 										mode_of_payment: values.mode_of_payment,
 										reference_number: values.reference_number,
 										reference_date: values.reference_date,
 										user_remark: values.user_remark,
-                },
-                callback: function (r) {
-                    frappe.msgprint("Payment info added successfully!");
+				},
+				callback: function (r) {
+					frappe.msgprint("Payment info added successfully!");
 										frm.reload_doc();
-                }
+				}
 						});
-            dialog.hide();
-        },
-        primary_action_label: __("Save")
-    });
-    dialog.show();
+			dialog.hide();
+		},
+		primary_action_label: __("Save")
+	});
+	dialog.show();
 }
 
 function showAssignEntryDialog(taskName){
 	var dialog = new frappe.ui.Dialog({
-        title: __("Add Employees"),
-        fields: [
+		title: __("Add Employees"),
+		fields: [
 						{
 								label: __("Assign To"),
 								fieldname: "assign_to",
@@ -608,25 +674,25 @@ function showAssignEntryDialog(taskName){
 									});
 								},
 						}
-        ],
-        primary_action: function (values) {
+		],
+		primary_action: function (values) {
 						frappe.call({
 								method: "frappe.desk.form.assign_to.add",
 								args: {
-                    doctype: "Task",
-                    name: taskName,
-                    assign_to: values.assign_to,
-                },
-                callback: function (r) {
-                    frappe.msgprint("Assignment added successfully!");
+					doctype: "Task",
+					name: taskName,
+					assign_to: values.assign_to,
+				},
+				callback: function (r) {
+					frappe.msgprint("Assignment added successfully!");
 										location.reload();
-                }
+				}
 						});
-            dialog.hide();
-        },
-        primary_action_label: __("Add")
-    });
-    dialog.show();
+			dialog.hide();
+		},
+		primary_action_label: __("Add")
+	});
+	dialog.show();
 }
 // Function to show the dialog box for timesheet entry
 function showTimeEntryDialog(page, taskName, projectName, assignees, startTime) {
@@ -634,7 +700,7 @@ function showTimeEntryDialog(page, taskName, projectName, assignees, startTime) 
 
 	var status = page.fields_dict.status.get_value();
   if (status === 'completed' | status === 'hold'| status === 'cancelled') {
-      return;
+	  return;
   }
 
 	// Get the pre-filled from_time and to_time values
@@ -642,60 +708,60 @@ function showTimeEntryDialog(page, taskName, projectName, assignees, startTime) 
   var toTime = frappe.datetime.now_datetime(); // Get the current date and time for the to_time field
 
 	var dialog = new frappe.ui.Dialog({
-        title: __("Time Entry Dialog"),
-        fields: [
+		title: __("Time Entry Dialog"),
+		fields: [
 						{
 								label: __("Employee"),
 								fieldname: "employee",
 								fieldtype: 'Select',
 								options: assigneesList,
-                default: get_employee(assigneesList, function (employee) {
-                    dialog.set_value("employee", employee);
-                })
+				default: get_employee(assigneesList, function (employee) {
+					dialog.set_value("employee", employee);
+				})
 						},
-            {
-                label: __("Project"),
-                fieldname: "project",
-                fieldtype: 'Link',
-                options: 'Project',
+			{
+				label: __("Project"),
+				fieldname: "project",
+				fieldtype: 'Link',
+				options: 'Project',
 								default: projectName
-            },
-            {
-                label: __("From Time"),
-                fieldname: "from_time",
-                fieldtype: 'Datetime',
-                reqd: true,
+			},
+			{
+				label: __("From Time"),
+				fieldname: "from_time",
+				fieldtype: 'Datetime',
+				reqd: true,
 								read_only: 1,
 								default: fromTime,
-            },
+			},
 						{
 							fieldtype: "Column Break",
 							fieldname: "col_break_1",
 						},
 						{
-                label: __("Task"),
-                fieldname: "task",
-                fieldtype: 'Link',
-                options: 'Task',
+				label: __("Task"),
+				fieldname: "task",
+				fieldtype: 'Link',
+				options: 'Task',
 								default: taskName
-            },
+			},
 						{
-                label: __("Activity"),
-                fieldname: "activity",
-                fieldtype: 'Link',
-                reqd: true,
+				label: __("Activity"),
+				fieldname: "activity",
+				fieldtype: 'Link',
+				reqd: true,
 								options: 'Activity Type'
-            },
-            {
-                label: __("To Time"),
-                fieldname: "to_time",
-                fieldtype: 'Datetime',
-                reqd: true,
+			},
+			{
+				label: __("To Time"),
+				fieldname: "to_time",
+				fieldtype: 'Datetime',
+				reqd: true,
 								read_only: 1,
 								default: toTime
-            }
-        ],
-        primary_action: function (values) {
+			}
+		],
+		primary_action: function (values) {
 						// Clear start time from local storage upon submitting timesheet
 						localStorage.removeItem("start-time-task-" + taskName + "-project-" + projectName);
 
@@ -718,13 +784,13 @@ function showTimeEntryDialog(page, taskName, projectName, assignees, startTime) 
 
 								}
 						});
-            dialog.hide();
-        },
-        primary_action_label: __("Submit")
-    });
+			dialog.hide();
+		},
+		primary_action_label: __("Submit")
+	});
 
-    // Show the dialog
-    dialog.show();
+	// Show the dialog
+	dialog.show();
 }
 
 // Function to get frappe.session.user in the employee field to filter the task
@@ -757,48 +823,48 @@ function set_status_colors(page) {
 				const projectElement = taskElement.querySelector('.card-subtitle');
 				let projectColor = projectElement.getAttribute('color')
 
-        if (status === 'Open') {
+		if (status === 'Open') {
 					statusElement.style.color = 'blue';
 					showTicIcon(statusElement);
 					projectElement.style.color = 'blue';
-        } else if (status === 'Completed') {
-            statusElement.style.color = 'green';
+		} else if (status === 'Completed') {
+			statusElement.style.color = 'green';
 						projectElement.style.color = 'green';
-        } else if (status === 'Overdue') {
-            statusElement.style.color = 'red';
+		} else if (status === 'Overdue') {
+			statusElement.style.color = 'red';
 						showTicIcon(statusElement);
 						projectElement.style.color = 'red';
-        } else if (status === 'Working') {
-            statusElement.style.color = 'tomato';
+		} else if (status === 'Working') {
+			statusElement.style.color = 'tomato';
 						showTicIcon(statusElement);
 						projectElement.style.color = 'tomato';
-        }
+		}
 
 				if (projectColor) {
-		        projectElement.style.color = projectColor;
-		    }
-    });
+				projectElement.style.color = projectColor;
+			}
+	});
 		// Show tic icon for status updation.
 		function showTicIcon(element) {
 			if (!element.querySelector('.fa-check-circle')) {
-        const ticIcon = document.createElement('i');
-        ticIcon.className = 'fas fa-check-circle';
-        ticIcon.style.color = 'green';
-        ticIcon.style.cursor = 'pointer';
+		const ticIcon = document.createElement('i');
+		ticIcon.className = 'fas fa-check-circle';
+		ticIcon.style.color = 'green';
+		ticIcon.style.cursor = 'pointer';
 				ticIcon.title = 'Update Status';
 
-        element.appendChild(document.createTextNode(' '));
-        element.appendChild(ticIcon);
+		element.appendChild(document.createTextNode(' '));
+		element.appendChild(ticIcon);
 
-        const taskName = element.getAttribute('task-name');
-        const taskId = element.getAttribute('task-id');
-        const projectId = element.getAttribute('project-id');
+		const taskName = element.getAttribute('task-name');
+		const taskId = element.getAttribute('task-id');
+		const projectId = element.getAttribute('project-id');
 				// Status updation to completed action for tic icon
-        ticIcon.addEventListener('click', function () {
-            update_status(page, taskName, projectId, taskId);
-        });
+		ticIcon.addEventListener('click', function () {
+			update_status(page, taskName, projectId, taskId);
+		});
 			}
-    }
+	}
 }
 
 function cusomerDocuments(subCategory, customer) {
@@ -912,25 +978,25 @@ function cusomerCredentials(subCategory, customer){
 
 function update_status(page, taskName, projectId, taskId) {
 	let fields = [
-	    {
-	        label: 'Status',
-	        fieldname: 'status',
-	        fieldtype: 'Select',
-	        options: 'Open\nWorking\nPending Review\nCompleted\nHold',
-	        default: 'Completed'
-	    },
-	    {
-	        label: 'Completed By',
-	        fieldname: 'completed_by',
-	        fieldtype: 'Link',
-	        options: 'User'
-	    },
-	    {
-	        label: 'Completed On',
-	        fieldname: 'completed_on',
-	        fieldtype: 'Date',
-	        default: 'Today'
-	    }
+		{
+			label: 'Status',
+			fieldname: 'status',
+			fieldtype: 'Select',
+			options: 'Open\nWorking\nPending Review\nCompleted\nHold',
+			default: 'Completed'
+		},
+		{
+			label: 'Completed By',
+			fieldname: 'completed_by',
+			fieldtype: 'Link',
+			options: 'User'
+		},
+		{
+			label: 'Completed On',
+			fieldname: 'completed_on',
+			fieldtype: 'Date',
+			default: 'Today'
+		}
 	];
 
 	let d = new frappe.ui.Dialog({
@@ -939,16 +1005,16 @@ function update_status(page, taskName, projectId, taskId) {
 		primary_action_label: 'Update',
 		primary_action(values) {
 			frappe.call({
-		    method: 'one_compliance.one_compliance.doc_events.task.update_task_status',
-		    args: {
-		      'task_id': taskId,
-		      'status': values.status,
-		      'completed_by': values.completed_by,
-		      'completed_on': values.completed_on
-		    },
-		    callback: function(r){
-		      if (r.message){
-		        d.hide();
+			method: 'one_compliance.one_compliance.doc_events.task.update_task_status',
+			args: {
+			  'task_id': taskId,
+			  'status': values.status,
+			  'completed_by': values.completed_by,
+			  'completed_on': values.completed_on
+			},
+			callback: function(r){
+			  if (r.message){
+				d.hide();
 						const selectedStatus = page.fields_dict.status.get_value();
 						const taskName = page.fields_dict.task.get_value();
 						const projectName = page.fields_dict.project.get_value();
@@ -961,8 +1027,8 @@ function update_status(page, taskName, projectId, taskId) {
 						const to_date = page.fields_dict.to_date.get_value();
 						refresh_tasks_manually(page, selectedStatus, taskName, projectName, customerName, department, subCategory, employee, employeeGroup, from_date, to_date)
 						// location.reload();
-		      }
-		    }
+			  }
+			}
 		  });
 		},
 	});

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
@@ -3,215 +3,249 @@ from frappe.utils import get_datetime
 from erpnext.accounts.party import get_party_account
 
 @frappe.whitelist()
-def get_task(status = None, task = None, project = None, customer = None, department = None, sub_category = None, employee = None, employee_group = None, from_date = None, to_date = None):
-    current_user = frappe.session.user
-    roles = frappe.get_roles(current_user)
-    user_id = f'"{employee}"' if id else None
+def get_task(status=None, task=None, project=None, customer=None, department=None, sub_category=None, employee=None, employee_group=None, from_date=None, to_date=None, page=1, page_length=20):
+	"""
+	Retrieve a filtered, paginated list of tasks from the Task Management Tool.
+	"""
+	current_user = frappe.session.user
+	roles = frappe.get_roles(current_user)
 
-    # Construct the SQL query to fetch list of tasks
-    query = """
-	SELECT
-        t.name,t.project,t.subject, t.project_name, t.customer, c.department, t.compliance_sub_category, t.exp_start_date, t.exp_end_date, t._assign, t.status, t.assigned_to, t.completed_by, t.color, t.custom_is_payable, t.readiness_status
-    FROM
-        tabTask t LEFT JOIN `tabCompliance Sub Category` c ON t.compliance_sub_category = c.name
-    """
+	conditions = []
+	values = {}
 
-    if status:
-            query += f" WHERE t.status = '{status}'"
-    else:
-        query += " WHERE t.status IN ('open', 'working', 'overdue')"
+	if status:
+		conditions.append("t.status = %(status)s")
+		values["status"] = status
+	else:
+		conditions.append("t.status IN ('open', 'working', 'overdue')")
 
-    if task:
-            query += f" AND t.name = '{task}'"
+	if task:
+		conditions.append("t.name = %(task)s")
+		values["task"] = task
 
-    if project:
-            query += f" AND t.project = '{project}'"
+	if project:
+		conditions.append("t.project = %(project)s")
+		values["project"] = project
 
-    if customer:
-            query += f" AND t.customer = '{customer}'"
+	if customer:
+		conditions.append("t.customer = %(customer)s")
+		values["customer"] = customer
 
-    if department:
-            query += f" AND c.department = '{department}'"
+	if department:
+		conditions.append("c.department = %(department)s")
+		values["department"] = department
 
-    if sub_category:
-            query += f" AND t.compliance_sub_category = '{sub_category}'"
+	if sub_category:
+		conditions.append("t.compliance_sub_category = %(sub_category)s")
+		values["sub_category"] = sub_category
 
-    if employee:
-            query += f" AND t._assign LIKE '%{user_id}%'"
+	if employee:
+		conditions.append("t._assign LIKE %(employee)s")
+		values["employee"] = f'%"{employee}"%'
 
-    if employee_group:
-            query += f" AND t.assigned_to = '{employee_group}'"
+	if employee_group:
+		conditions.append("t.assigned_to = %(employee_group)s")
+		values["employee_group"] = employee_group
 
-    if from_date:
-            query += f" AND t.exp_start_date >= '{from_date}'"
+	if from_date:
+		conditions.append("t.exp_start_date >= %(from_date)s")
+		values["from_date"] = from_date
 
-    if to_date:
-            query += f" AND t.exp_end_date < '{to_date}'"
+	if to_date:
+		conditions.append("t.exp_end_date < %(to_date)s")
+		values["to_date"] = to_date
 
+	# Only show tasks with readiness_status = "Ready" for Executive (excluding Administrator)
+	if current_user != "Administrator" and "Executive" in roles:
+		conditions.append("(t.readiness_status = 'Ready' OR t.readiness_status IS NULL OR t.readiness_status = '')")
 
-    # Only show tasks with readiness_status = "Ready" for Executive (excluding Administrator)
-    if current_user != "Administrator" and "Executive" in roles:
-        query +="AND (t.readiness_status = 'Ready' OR t.readiness_status IS NULL OR t.readiness_status = '')"
+	where_clause = "WHERE " + " AND ".join(conditions) if conditions else ""
 
-    query += """ ORDER BY
-            t.modified DESC;"""
+	# Count query
+	count_query = f"""
+		SELECT COUNT(t.name)
+		FROM tabTask t
+		LEFT JOIN `tabCompliance Sub Category` c ON t.compliance_sub_category = c.name
+		{where_clause}
+	"""
+	total_tasks = frappe.db.sql(count_query, values.copy(), as_dict=False)[0][0]
 
-    task_list = frappe.db.sql(query, as_dict=1)
-    for task in task_list:
-        task['employee_names'] = []
-        if task['_assign']:
-            user_ids = frappe.parse_json(task['_assign'])
+	# Data query
+	data_query = f"""
+		SELECT
+			t.name, t.project, t.subject, t.project_name, t.customer, c.department, t.compliance_sub_category,
+			t.exp_start_date, t.exp_end_date, t._assign, t.status, t.assigned_to, t.completed_by, t.color,
+			t.custom_is_payable, t.readiness_status
+		FROM
+			tabTask t LEFT JOIN `tabCompliance Sub Category` c ON t.compliance_sub_category = c.name
+		{where_clause}
+		ORDER BY
+			t.modified DESC
+		LIMIT %(page_length)s OFFSET %(offset)s
+	"""
+	values['page_length'] = int(page_length)
+	values['offset'] = (int(page) - 1) * int(page_length)
 
-            if user_ids:
-                user_names_query = """
-                    SELECT name, employee_name, user_id FROM `tabEmployee`
-                    WHERE user_id IN ({})
-                """.format(', '.join(['%s' for _ in user_ids]))
+	task_list = frappe.db.sql(data_query, values, as_dict=1)
 
-                user_names = frappe.db.sql(user_names_query, tuple(user_ids), as_dict=True)
-                task['_assign'] = [{'employee_name': user['employee_name'], 'employee_id': user['name']} for user in user_names]
-                task['employee_names'] = [user['employee_name'] for user in user_names]
-            else:
-                task['_assign'] = []
-                task['employee_names'] = []
-        else:
-            task['_assign'] = []
-            task['employee_names'] = []
+	for task_item in task_list:
+		task_item['employee_names'] = []
+		if task_item['_assign']:
+			user_ids = frappe.parse_json(task_item['_assign'])
+			if user_ids:
+				user_names_query = """
+					SELECT name, employee_name, user_id FROM `tabEmployee`
+					WHERE user_id IN ({})
+				""".format(', '.join(['%s' for _ in user_ids]))
+				user_names = frappe.db.sql(user_names_query, tuple(user_ids), as_dict=True)
+				task_item['_assign'] = [{'employee_name': user['employee_name'], 'employee_id': user['name']} for user in user_names]
+				task_item['employee_names'] = [user['employee_name'] for user in user_names]
+			else:
+				task_item['_assign'] = []
+				task_item['employee_names'] = []
+		else:
+			task_item['_assign'] = []
+			task_item['employee_names'] = []
 
-        if task['completed_by']:
-            if task['completed_by'] == 'Administrator':
-                task['completed_by_name'] = 'Administrator'
-            else:
-                completed_by = frappe.get_value("Employee", {"user_id": task['completed_by']}, ["name", "employee_name"], as_dict=True)
-                task['completed_by_name'] = completed_by["employee_name"]
-                task['completed_by_id'] = completed_by["name"]
-        else:
-            task['completed_by_name'] = []
-            task['completed_by_id'] = []
+		if task_item['completed_by']:
+			if task_item['completed_by'] == 'Administrator':
+				task_item['completed_by_name'] = 'Administrator'
+			else:
+				completed_by = frappe.get_value("Employee", {"user_id": task_item['completed_by']}, ["name", "employee_name"], as_dict=True)
+				if completed_by:
+					task_item['completed_by_name'] = completed_by.get("employee_name")
+					task_item['completed_by_id'] = completed_by.get("name")
+		else:
+			task_item['completed_by_name'] = []
+			task_item['completed_by_id'] = []
 
-    return task_list
+	return {
+		"tasks": task_list,
+		"total_tasks": total_tasks
+	}
+
 
 @frappe.whitelist()
 def create_timesheet(project, task, employee, activity, from_time, to_time):
 
-    from_time = get_datetime(from_time)
-    to_time = get_datetime(to_time)
-    employee_id = frappe.get_value("Employee", {"employee_name": employee}, "name")
+	from_time = get_datetime(from_time)
+	to_time = get_datetime(to_time)
+	employee_id = frappe.get_value("Employee", {"employee_name": employee}, "name")
 
-    # Check if a timesheet already exists for the employee within the given date range
-    existing_timesheets = frappe.get_all("Timesheet", filters={
-        "employee": employee_id,
-        "start_date": from_time.date(),
-        "end_date": to_time.date(),
-    })
+	# Check if a timesheet already exists for the employee within the given date range
+	existing_timesheets = frappe.get_all("Timesheet", filters={
+		"employee": employee_id,
+		"start_date": from_time.date(),
+		"end_date": to_time.date(),
+	})
 
-    if existing_timesheets:
-        existing_timesheet = frappe.get_doc("Timesheet", existing_timesheets)
-        existing_timesheet.append("time_logs",{
-            "activity_type": activity,
-            "project": project,
-            "task": task,
-            "from_time": from_time,
-            "to_time": to_time
-        })
-        existing_timesheet.save()
-        frappe.db.commit()
-    else:
-        timesheet = frappe.new_doc("Timesheet")
-        timesheet.employee = employee_id
-        timesheet.append("time_logs",{
-            "activity_type": activity,
-            "project": project,
-            "task": task,
-            "from_time": from_time,
-            "to_time": to_time
-        })
+	if existing_timesheets:
+		existing_timesheet = frappe.get_doc("Timesheet", existing_timesheets)
+		existing_timesheet.append("time_logs",{
+			"activity_type": activity,
+			"project": project,
+			"task": task,
+			"from_time": from_time,
+			"to_time": to_time
+		})
+		existing_timesheet.save()
+		frappe.db.commit()
+	else:
+		timesheet = frappe.new_doc("Timesheet")
+		timesheet.employee = employee_id
+		timesheet.append("time_logs",{
+			"activity_type": activity,
+			"project": project,
+			"task": task,
+			"from_time": from_time,
+			"to_time": to_time
+		})
 
-        timesheet.insert(ignore_permissions=True)
-        frappe.db.commit()
+		timesheet.insert(ignore_permissions=True)
+		frappe.db.commit()
 
 @frappe.whitelist()
 def update_task_status(task, project, status):
-    task_doc = frappe.get_doc("Task", {"name":task,"project":project})
+	task_doc = frappe.get_doc("Task", {"name":task,"project":project})
 
-    task_doc.status = status
+	task_doc.status = status
 
-    task_doc.save()
-    return "success"
+	task_doc.save()
+	return "success"
 
 
 @frappe.whitelist()
 def add_payment_info(task_id, payable_amount, mode_of_payment, reference_number=None, reference_date=None, user_remark=None):
-    task_doc = frappe.get_doc("Task", task_id)
-    payment_info = {
-        "payable_amount": payable_amount,
-        "mode_of_payment": mode_of_payment,
-        "reference_number": reference_number,
-        "reference_date": reference_date,
-        "user_remark": user_remark
-    }
-    journal_entry = create_journal_entry_pay_info(task_doc, payment_info)
-    payment_info['journal_entry'] = journal_entry
-    task_doc.append("custom_task_payment_informations", payment_info)
-    task_doc.custom_is_payable = 1
-    # task_doc.custom_payable_amount = payable_amount
-    # task_doc.custom_mode_of_payment = mode_of_payment
-    # task_doc.custom_reference_number = reference_number
-    # task_doc.custom_reference_date = reference_date
-    # task_doc.custom_user_remark = user_remark
-    task_doc.save()
-    task_doc.reload()
-    sales_order = frappe.db.get_value("Project", task_doc.project, 'sales_order') or None
-    if sales_order:
-        so_reimburse = frappe.new_doc('Reimbursement Details')
-        so_reimburse.parent = sales_order
-        so_reimburse.parentfield = 'custom_reimbursement_details'
-        so_reimburse.parenttype = 'Sales Order'
-        so_reimburse.journal_entry = journal_entry
-        so_reimburse.date = reference_date
-        so_reimburse.amount = payable_amount
-        so_reimburse.user_remark = user_remark
-        so_reimburse.save(ignore_permissions= True)
-        total_reimbursement_amount = get_total_reimbursement_amount(sales_order)
-        frappe.db.set_value('Sales Order', sales_order, 'custom_total_reimbursement_amount', total_reimbursement_amount)
-    frappe.db.commit()
+	task_doc = frappe.get_doc("Task", task_id)
+	payment_info = {
+		"payable_amount": payable_amount,
+		"mode_of_payment": mode_of_payment,
+		"reference_number": reference_number,
+		"reference_date": reference_date,
+		"user_remark": user_remark
+	}
+	journal_entry = create_journal_entry_pay_info(task_doc, payment_info)
+	payment_info['journal_entry'] = journal_entry
+	task_doc.append("custom_task_payment_informations", payment_info)
+	task_doc.custom_is_payable = 1
+	# task_doc.custom_payable_amount = payable_amount
+	# task_doc.custom_mode_of_payment = mode_of_payment
+	# task_doc.custom_reference_number = reference_number
+	# task_doc.custom_reference_date = reference_date
+	# task_doc.custom_user_remark = user_remark
+	task_doc.save()
+	task_doc.reload()
+	sales_order = frappe.db.get_value("Project", task_doc.project, 'sales_order') or None
+	if sales_order:
+		so_reimburse = frappe.new_doc('Reimbursement Details')
+		so_reimburse.parent = sales_order
+		so_reimburse.parentfield = 'custom_reimbursement_details'
+		so_reimburse.parenttype = 'Sales Order'
+		so_reimburse.journal_entry = journal_entry
+		so_reimburse.date = reference_date
+		so_reimburse.amount = payable_amount
+		so_reimburse.user_remark = user_remark
+		so_reimburse.save(ignore_permissions= True)
+		total_reimbursement_amount = get_total_reimbursement_amount(sales_order)
+		frappe.db.set_value('Sales Order', sales_order, 'custom_total_reimbursement_amount', total_reimbursement_amount)
+	frappe.db.commit()
 
 def create_journal_entry_pay_info(task, payment_info):
-    if payment_info['payable_amount'] and payment_info['mode_of_payment']:
-        account = get_party_account('Customer', task.customer, task.company)
-        default_account = get_default_account_for_mode_of_payment(payment_info['mode_of_payment'], task.company)
-        journal_entry = frappe.new_doc('Journal Entry')
-        journal_entry.voucher_type = 'Bank Entry'
-        journal_entry.company = task.company
-        journal_entry.cheque_no = payment_info['reference_number']
-        journal_entry.cheque_date = payment_info['reference_date']
-        journal_entry.user_remark = payment_info['user_remark']
-        journal_entry.posting_date = frappe.utils.today()
-        journal_entry.append('accounts', {
-            'account': account,
-            'party_type': 'Customer',
-            'party': task.customer,
-            'project': task.project,
-            'debit_in_account_currency': payment_info['payable_amount']
-        })
-        journal_entry.append('accounts', {
-            'account': default_account,
-            'project': task.project,
-            'credit_in_account_currency': payment_info['payable_amount']
-        })
-        journal_entry.insert(ignore_permissions=True)
-        return journal_entry.name
+	if payment_info['payable_amount'] and payment_info['mode_of_payment']:
+		account = get_party_account('Customer', task.customer, task.company)
+		default_account = get_default_account_for_mode_of_payment(payment_info['mode_of_payment'], task.company)
+		journal_entry = frappe.new_doc('Journal Entry')
+		journal_entry.voucher_type = 'Bank Entry'
+		journal_entry.company = task.company
+		journal_entry.cheque_no = payment_info['reference_number']
+		journal_entry.cheque_date = payment_info['reference_date']
+		journal_entry.user_remark = payment_info['user_remark']
+		journal_entry.posting_date = frappe.utils.today()
+		journal_entry.append('accounts', {
+			'account': account,
+			'party_type': 'Customer',
+			'party': task.customer,
+			'project': task.project,
+			'debit_in_account_currency': payment_info['payable_amount']
+		})
+		journal_entry.append('accounts', {
+			'account': default_account,
+			'project': task.project,
+			'credit_in_account_currency': payment_info['payable_amount']
+		})
+		journal_entry.insert(ignore_permissions=True)
+		return journal_entry.name
 
 def get_default_account_for_mode_of_payment(mode_of_payment, company):
-    mode_of_payment_doc = frappe.get_doc("Mode of Payment", mode_of_payment)
-    for account in mode_of_payment_doc.accounts:
-        if account.company == company:
-            return account.default_account
-    frappe.throw(_("Default account not found for mode of payment {0} and company {1}").format(mode_of_payment, company))
+	mode_of_payment_doc = frappe.get_doc("Mode of Payment", mode_of_payment)
+	for account in mode_of_payment_doc.accounts:
+		if account.company == company:
+			return account.default_account
+	frappe.throw(_("Default account not found for mode of payment {0} and company {1}").format(mode_of_payment, company))
 
 def get_total_reimbursement_amount(sales_order):
-    total_reimbursement_amount = 0
-    amounts = frappe.db.get_all('Reimbursement Details', { 'parent':sales_order, 'parentfield':'custom_reimbursement_details', 'parenttype':'Sales Order'}, pluck='amount')
-    for amount in amounts:
-        total_reimbursement_amount += amount
-    return total_reimbursement_amount
+	total_reimbursement_amount = 0
+	amounts = frappe.db.get_all('Reimbursement Details', { 'parent':sales_order, 'parentfield':'custom_reimbursement_details', 'parenttype':'Sales Order'}, pluck='amount')
+	for amount in amounts:
+		total_reimbursement_amount += amount
+	return total_reimbursement_amount

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.utils import get_datetime
 from erpnext.accounts.party import get_party_account
+from frappe import _
 
 @frappe.whitelist()
 def get_task(status=None, task=None, project=None, customer=None, department=None, sub_category=None, employee=None, employee_group=None, from_date=None, to_date=None, page=1, page_length=20):
@@ -55,13 +56,11 @@ def get_task(status=None, task=None, project=None, customer=None, department=Non
 		conditions.append("t.exp_end_date < %(to_date)s")
 		values["to_date"] = to_date
 
-	# Only show tasks with readiness_status = "Ready" for Executive (excluding Administrator)
 	if current_user != "Administrator" and "Executive" in roles:
 		conditions.append("(t.readiness_status = 'Ready' OR t.readiness_status IS NULL OR t.readiness_status = '')")
 
 	where_clause = "WHERE " + " AND ".join(conditions) if conditions else ""
 
-	# Count query
 	count_query = f"""
 		SELECT COUNT(t.name)
 		FROM tabTask t
@@ -70,7 +69,6 @@ def get_task(status=None, task=None, project=None, customer=None, department=Non
 	"""
 	total_tasks = frappe.db.sql(count_query, values.copy(), as_dict=False)[0][0]
 
-	# Data query
 	data_query = f"""
 		SELECT
 			t.name, t.project, t.subject, t.project_name, t.customer, c.department, t.compliance_sub_category,
@@ -124,15 +122,15 @@ def get_task(status=None, task=None, project=None, customer=None, department=Non
 		"total_tasks": total_tasks
 	}
 
-
 @frappe.whitelist()
 def create_timesheet(project, task, employee, activity, from_time, to_time):
-
+	"""
+	Create or update a Timesheet for an employee based on provided time logs.
+	"""
 	from_time = get_datetime(from_time)
 	to_time = get_datetime(to_time)
 	employee_id = frappe.get_value("Employee", {"employee_name": employee}, "name")
 
-	# Check if a timesheet already exists for the employee within the given date range
 	existing_timesheets = frappe.get_all("Timesheet", filters={
 		"employee": employee_id,
 		"start_date": from_time.date(),
@@ -149,7 +147,6 @@ def create_timesheet(project, task, employee, activity, from_time, to_time):
 			"to_time": to_time
 		})
 		existing_timesheet.save()
-		frappe.db.commit()
 	else:
 		timesheet = frappe.new_doc("Timesheet")
 		timesheet.employee = employee_id
@@ -162,10 +159,12 @@ def create_timesheet(project, task, employee, activity, from_time, to_time):
 		})
 
 		timesheet.insert(ignore_permissions=True)
-		frappe.db.commit()
 
 @frappe.whitelist()
 def update_task_status(task, project, status):
+	"""
+	Create or update a Timesheet for an employee based on provided time logs.
+	"""
 	task_doc = frappe.get_doc("Task", {"name":task,"project":project})
 
 	task_doc.status = status
@@ -173,9 +172,11 @@ def update_task_status(task, project, status):
 	task_doc.save()
 	return "success"
 
-
 @frappe.whitelist()
 def add_payment_info(task_id, payable_amount, mode_of_payment, reference_number=None, reference_date=None, user_remark=None):
+	"""
+	Add payment details to a task and create related Journal Entry and Reimbursement records.
+	"""
 	task_doc = frappe.get_doc("Task", task_id)
 	payment_info = {
 		"payable_amount": payable_amount,
@@ -188,11 +189,6 @@ def add_payment_info(task_id, payable_amount, mode_of_payment, reference_number=
 	payment_info['journal_entry'] = journal_entry
 	task_doc.append("custom_task_payment_informations", payment_info)
 	task_doc.custom_is_payable = 1
-	# task_doc.custom_payable_amount = payable_amount
-	# task_doc.custom_mode_of_payment = mode_of_payment
-	# task_doc.custom_reference_number = reference_number
-	# task_doc.custom_reference_date = reference_date
-	# task_doc.custom_user_remark = user_remark
 	task_doc.save()
 	task_doc.reload()
 	sales_order = frappe.db.get_value("Project", task_doc.project, 'sales_order') or None
@@ -208,9 +204,11 @@ def add_payment_info(task_id, payable_amount, mode_of_payment, reference_number=
 		so_reimburse.save(ignore_permissions= True)
 		total_reimbursement_amount = get_total_reimbursement_amount(sales_order)
 		frappe.db.set_value('Sales Order', sales_order, 'custom_total_reimbursement_amount', total_reimbursement_amount)
-	frappe.db.commit()
 
 def create_journal_entry_pay_info(task, payment_info):
+	"""
+	Create a Journal Entry for the provided payment information.
+	"""
 	if payment_info['payable_amount'] and payment_info['mode_of_payment']:
 		account = get_party_account('Customer', task.customer, task.company)
 		default_account = get_default_account_for_mode_of_payment(payment_info['mode_of_payment'], task.company)
@@ -237,6 +235,9 @@ def create_journal_entry_pay_info(task, payment_info):
 		return journal_entry.name
 
 def get_default_account_for_mode_of_payment(mode_of_payment, company):
+	"""
+	Get the default account for the specified mode of payment and company.
+	"""
 	mode_of_payment_doc = frappe.get_doc("Mode of Payment", mode_of_payment)
 	for account in mode_of_payment_doc.accounts:
 		if account.company == company:
@@ -244,6 +245,9 @@ def get_default_account_for_mode_of_payment(mode_of_payment, company):
 	frappe.throw(_("Default account not found for mode of payment {0} and company {1}").format(mode_of_payment, company))
 
 def get_total_reimbursement_amount(sales_order):
+	"""
+	Calculate the total reimbursement amount for a given Sales Order
+	"""
 	total_reimbursement_amount = 0
 	amounts = frappe.db.get_all('Reimbursement Details', { 'parent':sales_order, 'parentfield':'custom_reimbursement_details', 'parenttype':'Sales Order'}, pluck='amount')
 	for amount in amounts:


### PR DESCRIPTION
- [x] TASK-2025-02497
- [x]  TASK-2025-02531

## Feature description
Need to Implement Pagination in Task Management Tool

## Solution description

- The Task Management Tool now supports pagination, improving load time and performance for large Task datasets.
- Tasks are displayed 20 per page by default
- Previous and Next buttons appear below the Task list for navigation.
- Previous button is disabled on the first page, and Next button is disabled on the last page.
- Added page size selector ( 20, 100, 500, 2500 records per page)
- Corrected Indentation into tab spaces
- 
## Output screenshots (optional)

## Areas affected and ensured
Task Management Tool

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  
