### PR TITLE
feat:created custom fields  customer type for opportunity

### DIFF
--- a/one_compliance/custom/custom_field/opportunity.py
+++ b/one_compliance/custom/custom_field/opportunity.py
@@ -35,6 +35,13 @@ def get_opportunity_custom_fields():
 				"fieldtype": "Small Text",
 				"label": "Follow up Reply",			
 				"insert_after": "open_activities_html"
-			}
+			},
+			{
+				"fieldname": "custom_customer_type",
+				"fieldtype": "Link",
+				"label": "Customer Type",
+				"options": "Customer Type",
+				"insert_after": "website"
+			},
 		]
 	}


### PR DESCRIPTION
## Feature description
Created custom fields for customer type for opportunity

- [x] TASK-2025-02684

## Solution description
**Issue  :**
The system throws an AttributeError when creating a customer from an Opportunity because the script attempts to access a non-existent field, "custom_customer_type," to create a client in the Opportunity DocType.

**solution:**
      The issue occurred because the Opportunity DocType did not contain the custom field 'custom_customer_type', but the custom script attempted to access it while creating a Customer. This resulted in an AttributeError during the Customer creation process.

- To resolve this:

Added the missing custom field
A new custom field, custom_customer_type (Link → Customer Type), was created inside the Opportunity DocType.

The script now successfully reads the custom_customer_type value from the Opportunity and falls back to the default Customer Type configured in Compliance Settings if the field is empty.

After adding the field, creating a Sales Order from an Opportunity correctly triggers the customer creation, and the system now creates the Customer document.


## Areas affected and ensured
sales order and client 

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
