### PR TITLE
feat: Docuemnts Required field in Project Template

### DIFF
--- a/one_compliance/one_compliance/doctype/premium_tasks/premium_tasks.json
+++ b/one_compliance/one_compliance/doctype/premium_tasks/premium_tasks.json
@@ -62,7 +62,7 @@
   },
   {
    "columns": 2,
-   "depends_on": "eval:doc.custom_has_document",
+   "depends_on": "eval:doc.has_document",
    "fieldname": "documents_required",
    "fieldtype": "Button",
    "in_list_view": 1,
@@ -89,7 +89,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-19 17:17:21.208776",
+ "modified": "2025-11-25 11:52:02.083772",
  "modified_by": "Administrator",
  "module": "One Compliance",
  "name": "Premium Tasks",

--- a/one_compliance/public/js/project_template.js
+++ b/one_compliance/public/js/project_template.js
@@ -1,112 +1,162 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 frappe.ui.form.on('Project Template', {
-    setup(frm) {
-        set_filters(frm);
-        restrict_task_field(frm, 'tasks');
-        restrict_task_field(frm, 'premium_tasks');
-    },
-    refresh(frm) {
-        clear_blank_rows(frm, ["tasks", "premium_tasks"]);
-    },
-    custom_add_tasks(frm) {
-        show_task_popup(frm, 'tasks');
-    },
-    custom_add_tasks2(frm) {
-        show_task_popup(frm, 'premium_tasks');
-    }
+	setup(frm) {
+		set_filters(frm);
+		restrict_task_field(frm, 'tasks');
+		restrict_task_field(frm, 'premium_tasks');
+	},
+	refresh(frm) {
+		clear_blank_rows(frm, ["tasks", "premium_tasks"]);
+	},
+	custom_add_tasks(frm) {
+		show_task_popup(frm, 'tasks');
+	},
+	custom_add_tasks2(frm) {
+		show_task_popup(frm, 'premium_tasks');
+	}
 });
 
 frappe.ui.form.on('Project Template Task', {
-    custom_documents_required(frm, cdt, cdn) {
-        const child = locals[cdt][cdn];
-        if (child.custom_has_document) {
-            if (frm.is_new()) {
-                frappe.throw('You need to save the document to perform this action.');
-            } else {
-                frappe.call({
-                    method: 'one_compliance.one_compliance.doc_events.project_template.get_existing_documents',
-                    args: {
-                        template: frm.doc.name,
-                        task: child.task,
-                    },
-                    callback(r) {
-                        if (r.message) {
-                            documents_required_popup(frm, r.message, child);
-                        }
-                    }
-                });
-            }
-        }
+	custom_documents_required(frm, cdt, cdn) {
+		const child = locals[cdt][cdn];
+		if (child.custom_has_document) {
+			if (frm.is_new()) {
+				frappe.throw('You need to save the document to perform this action.');
+			} else {
+				frappe.call({
+					method: 'one_compliance.one_compliance.doc_events.project_template.get_existing_documents',
+					args: {
+						template: frm.doc.name,
+						task: child.task,
+					},
+					callback(r) {
+						if (r.message) {
+							documents_required_popup(frm, r.message, child);
+						}
+					}
+				});
+			}
+		}
+	},
+	custom_has_document(frm, cdt, cdn) {
+		const child = locals[cdt][cdn];
+		if (!child.custom_has_document) {
+			frm.doc.custom_documents_required = (frm.doc.custom_documents_required || []).filter(
+				row => row.task !== child.task
+			);
+			frm.refresh_field('custom_documents_required');
+		}
+	}
+});
+
+frappe.ui.form.on('Premium Tasks', {
+    documents_required: function(frm, cdt, cdn) {
+        handle_documents_required(frm, cdt, cdn);
     },
-    custom_has_document(frm, cdt, cdn) {
-        const child = locals[cdt][cdn];
-        if (!child.custom_has_document) {
-            frm.doc.custom_documents_required = (frm.doc.custom_documents_required || []).filter(
-                row => row.task !== child.task
-            );
-            frm.refresh_field('custom_documents_required');
-        }
+
+    has_document: function(frm, cdt, cdn) {
+        handle_has_document(frm, cdt, cdn);
     }
 });
+
+/**
+ * Event handlers for the 'Premium Tasks' child table in the 'Project Template' form.
+ * Manages the logic for handling required documents associated with premium tasks.
+ */
+function handle_documents_required(frm, cdt, cdn) {
+    const child = locals[cdt][cdn];
+
+    if (child.has_document) {
+        if (frm.is_new()) {
+            frappe.throw('You need to save the document to perform this action.');
+        } else {
+            frappe.call({
+                method: 'one_compliance.one_compliance.doc_events.project_template.get_existing_documents',
+                args: {
+                    template: frm.doc.name,
+                    task: child.task,
+                },
+                callback(r) {
+                    if (r.message) {
+                        documents_required_popup(frm, r.message, child);
+                    }
+                }
+            });
+        }
+    }
+}
+
+/**
+ * Removes entries from the 'documents_required' table when 'has_document' is unchecked.
+ */
+function handle_has_document(frm, cdt, cdn) {
+	const child = locals[cdt][cdn];
+	if (!child.has_document) {
+		frm.doc.custom_documents_required = (frm.doc.custom_documents_required || []).filter(
+			row => row.task !== child.task
+		);
+		frm.refresh_field('custom_documents_required');
+	}
+}
 
 /**
  * Sets up filters and restricts row addition for task and premium task tables on the Project Template form.
  * Called during the form's setup event.
  */
 function set_filters(frm) {
-    frm.set_query('compliance_sub_category', () => ({
-        filters: { compliance_category: frm.doc.compliance_category }
-    }));
+	frm.set_query('compliance_sub_category', () => ({
+		filters: { compliance_category: frm.doc.compliance_category }
+	}));
 }
 
 /**
  * Displays a dialog to select or create documents required for a task.
  */
 function documents_required_popup(frm, documents_required, child) {
-    const dialog = new frappe.ui.Dialog({
-        title: __("Documents Required"),
-        fields: [
-            {
-                label: __("Documents Required"),
-                fieldname: "documents_required",
-                fieldtype: 'MultiSelectPills',
-                default: documents_required,
-                get_data: txt => frappe.db.get_link_options("Task Document", txt),
-            }
-        ],
-        primary_action_label: __("Save"),
-        primary_action(values) {
-            update_documents_required(frm, values, child);
-            dialog.hide();
-        },
-        secondary_action_label: __("Create a New Task Document"),
-        secondary_action() {
-            frappe.new_doc('Task Document');
-        }
-    });
-    dialog.show();
+	const dialog = new frappe.ui.Dialog({
+		title: __("Documents Required"),
+		fields: [
+			{
+				label: __("Documents Required"),
+				fieldname: "documents_required",
+				fieldtype: 'MultiSelectPills',
+				default: documents_required,
+				get_data: txt => frappe.db.get_link_options("Task Document", txt),
+			}
+		],
+		primary_action_label: __("Save"),
+		primary_action(values) {
+			update_documents_required(frm, values, child);
+			dialog.hide();
+		},
+		secondary_action_label: __("Create a New Task Document"),
+		secondary_action() {
+			frappe.new_doc('Task Document');
+		}
+	});
+	dialog.show();
 }
 
 /**
  * Calls the backend to update the documents required for a task.
  */
 function update_documents_required(frm, values, child) {
-    frappe.call({
-        method: 'one_compliance.one_compliance.doc_events.project_template.update_documents_required',
-        args: {
-            template: frm.doc.name,
-            documents: values.documents_required,
-            task: child.task,
-        },
-        callback(r) {
-            if (r.message === 'success') {
-                frm.reload_doc();
-            } else {
-                frappe.msgprint('Error: Unable to update documents required.');
-            }
-        }
-    });
+	frappe.call({
+		method: 'one_compliance.one_compliance.doc_events.project_template.update_documents_required',
+		args: {
+			template: frm.doc.name,
+			documents: values.documents_required,
+			task: child.task,
+		},
+		callback(r) {
+			if (r.message === 'success') {
+				frm.reload_doc();
+			} else {
+				frappe.msgprint('Error: Unable to update documents required.');
+			}
+		}
+	});
 }
 
 /**
@@ -115,13 +165,13 @@ function update_documents_required(frm, values, child) {
  * @param {string} table_field - The name of the child table field (e.g., 'tasks' or 'premium_tasks').
  */
 function restrict_task_field(frm, table_field) {
-    const grid = frm.fields_dict[table_field].grid;
-    grid.update_docfield_property('task', 'only_select', 1);
-    grid.cannot_add_rows = true;
-    grid.refresh();
-    if (grid.wrapper) {
-        grid.wrapper.find('.grid-add-row').hide();
-    }
+	const grid = frm.fields_dict[table_field].grid;
+	grid.update_docfield_property('task', 'only_select', 1);
+	grid.cannot_add_rows = true;
+	grid.refresh();
+	if (grid.wrapper) {
+		grid.wrapper.find('.grid-add-row').hide();
+	}
 }
 
 /**
@@ -130,56 +180,56 @@ function restrict_task_field(frm, table_field) {
  * @param {string} table_field - The name of the child table field.
  */
 function show_task_popup(frm, table_field) {
-    let primary_action_label = 'Create & Add';
-    const dialog = new frappe.ui.Dialog({
-        title: 'Task details',
-        fields: [
-            {
-                label: 'Is Existing Task',
-                fieldname: 'is_existing_task',
-                fieldtype: 'Check',
-                change: () => {
-                    primary_action_label = dialog.get_value('is_existing_task') ? 'Add' : 'Create & Add';
-                    set_primary_action_label(dialog, primary_action_label);
-                }
-            },
-            {
-                label: 'Task',
-                fieldname: 'task',
-                fieldtype: 'Link',
-                options: 'Task',
-                only_select: 1,
-                get_query: () => ({ filters: { is_template: 1 } }),
-                depends_on: 'eval: doc.is_existing_task',
-                mandatory_depends_on: 'eval: doc.is_existing_task',
-                change: () => {
-                    const task = dialog.get_value('task');
-                    if (task) {
-                        frappe.db.get_value('Task', task, 'subject').then(r => {
-                            dialog.set_value('subject', r.message.subject || '');
-                        });
-                    }
-                }
-            },
-            {
-                label: 'Subject',
-                fieldname: 'subject',
-                fieldtype: 'Data',
-                depends_on: 'eval: !doc.is_existing_task',
-                mandatory_depends_on: 'eval: !doc.is_existing_task',
-            }
-        ],
-        primary_action_label,
-        primary_action(values) {
-            if (values.is_existing_task) {
-                add_task_row(frm, table_field, values.task, values.subject);
-            } else {
-                create_task(frm, table_field, values.subject);
-            }
-            dialog.hide();
-        }
-    });
-    dialog.show();
+	let primary_action_label = 'Create & Add';
+	const dialog = new frappe.ui.Dialog({
+		title: 'Task details',
+		fields: [
+			{
+				label: 'Is Existing Task',
+				fieldname: 'is_existing_task',
+				fieldtype: 'Check',
+				change: () => {
+					primary_action_label = dialog.get_value('is_existing_task') ? 'Add' : 'Create & Add';
+					set_primary_action_label(dialog, primary_action_label);
+				}
+			},
+			{
+				label: 'Task',
+				fieldname: 'task',
+				fieldtype: 'Link',
+				options: 'Task',
+				only_select: 1,
+				get_query: () => ({ filters: { is_template: 1 } }),
+				depends_on: 'eval: doc.is_existing_task',
+				mandatory_depends_on: 'eval: doc.is_existing_task',
+				change: () => {
+					const task = dialog.get_value('task');
+					if (task) {
+						frappe.db.get_value('Task', task, 'subject').then(r => {
+							dialog.set_value('subject', r.message.subject || '');
+						});
+					}
+				}
+			},
+			{
+				label: 'Subject',
+				fieldname: 'subject',
+				fieldtype: 'Data',
+				depends_on: 'eval: !doc.is_existing_task',
+				mandatory_depends_on: 'eval: !doc.is_existing_task',
+			}
+		],
+		primary_action_label,
+		primary_action(values) {
+			if (values.is_existing_task) {
+				add_task_row(frm, table_field, values.task, values.subject);
+			} else {
+				create_task(frm, table_field, values.subject);
+			}
+			dialog.hide();
+		}
+	});
+	dialog.show();
 }
 
 /**
@@ -189,16 +239,16 @@ function show_task_popup(frm, table_field) {
  * @param {string} subject - The subject/title of the new task.
  */
 function create_task(frm, table_field, subject) {
-    frappe.db.insert({
-        doctype: 'Task',
-        subject,
-        is_template: 1,
-        status: 'Template'
-    }).then(doc => {
-        if (doc.name) {
-            add_task_row(frm, table_field, doc.name, subject);
-        }
-    });
+	frappe.db.insert({
+		doctype: 'Task',
+		subject,
+		is_template: 1,
+		status: 'Template'
+	}).then(doc => {
+		if (doc.name) {
+			add_task_row(frm, table_field, doc.name, subject);
+		}
+	});
 }
 
 /**
@@ -209,9 +259,9 @@ function create_task(frm, table_field, subject) {
  * @param {string} subject - The subject/title of the task.
  */
 function add_task_row(frm, table_field, task, subject) {
-    frm.add_child(table_field, { task, subject });
-    frm.refresh_field(table_field);
-    restrict_task_field(frm, table_field);
+	frm.add_child(table_field, { task, subject });
+	frm.refresh_field(table_field);
+	restrict_task_field(frm, table_field);
 }
 
 /**
@@ -220,14 +270,14 @@ function add_task_row(frm, table_field, task, subject) {
  * @param {Array<string>} tables - List of child table fieldnames.
  */
 function clear_blank_rows(frm, tables) {
-    if (frm.is_new()) {
-        tables.forEach(table_field => {
-            frm.clear_table(table_field);
-            frm.refresh_field(table_field);
-        });
-    }
+	if (frm.is_new()) {
+		tables.forEach(table_field => {
+			frm.clear_table(table_field);
+			frm.refresh_field(table_field);
+		});
+	}
 }
 
 function set_primary_action_label(dialog, primary_action_label) {
-    dialog.get_primary_btn().removeClass("hide").html(primary_action_label);
+	dialog.get_primary_btn().removeClass("hide").html(primary_action_label);
 }


### PR DESCRIPTION
## Feature description

- [x] TASK-2025-02721

Added  Docuemnts Required field in Project Template

## Solution description

- Replaced depends_on condition from custom_has_document → has_document in Premium Tasks DocType
  so that the "Documents Required" button shows only when the correct checkbox is enabled.
- Added complete JS event handlers for Premium Tasks:
    • Opens document selection popup when has_document is checked
- then selected documents added into the Documents Required child table


## Output screenshots (optional)

[Screencast from 25-11-25 03:02:38 PM IST.webm](https://github.com/user-attachments/assets/f11111bc-1d70-460b-838a-598759cd2ef6)


## Areas affected and ensured
project template

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
