### PR TITLE
TASK-2025-02725: incorrect status filtering

### DIFF
--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
@@ -92,8 +92,6 @@ function make_filters(page) {
 			{ label: "Pending Review", value: "pending_review" },
 			{ label: "Overdue", value: "overdue" },
 			{ label: "Hold", value: "hold" },
-			{ label: "Completed", value: "completed" },
-			{ label: "Cancelled", value: "cancelled" },
 		],
 		default: "",
 		change() {
@@ -622,17 +620,19 @@ function set_status_colors(page) {
 		const project_color = project_el.attr("color");
 
 		const color_map = {
-			Open: "blue",
-			Completed: "green",
-			Overdue: "red",
-			Working: "tomato",
+			"Open": "blue",
+			"Completed": "green",
+			"Overdue": "red",
+			"Working": "tomato",
+			"Pending Review": "orange",
+			"Hold": "gray",
 		};
 
 		const color = color_map[status] || project_color;
 		status_el.css("color", color);
 		project_el.css("color", color);
 
-		if (["Open", "Overdue", "Working"].includes(status)) add_check_icon(status_el[0]);
+		if (["Open", "Overdue", "Working", "Pending Review", "Hold"].includes(status)) add_check_icon(status_el[0]);
 	});
 
 	function add_check_icon(element) {
@@ -782,20 +782,7 @@ function update_status(page, task_name, project_id, task_id) {
 				callback(r) {
 					if (r.message) {
 						dialog.hide();
-						const f = page.fields_dict;
-						refresh_tasks_manually(
-							page,
-							f.status.get_value(),
-							f.task.get_value(),
-							f.project.get_value(),
-							f.customer.get_value(),
-							f.department.get_value(),
-							f.compliance_sub_category.get_value(),
-							f.employee.get_value(),
-							f.employee_group.get_value(),
-							f.from_date.get_value(),
-							f.to_date.get_value()
-						);
+						refresh_tasks(page);
 					}
 				},
 			});

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
@@ -757,7 +757,7 @@ function update_status(page, task_name, project_id, task_id) {
 				label: __("Status"),
 				fieldname: "status",
 				fieldtype: "Select",
-				options: "Open\nWorking\nPending Review\nCompleted\nHold",
+				options: "Open\nWorking\nPending Review\nHold\nCompleted",
 				default: "Completed",
 			},
 			{

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
@@ -21,6 +21,8 @@ def get_task(status=None, task=None, project=None, customer=None, department=Non
 			proper_status = status.replace("_", " ").title()
 			conditions.append("t.status = %(status)s")
 			values["status"] = proper_status
+	else:
+		conditions.append("t.status NOT IN ('Completed', 'Cancelled')")
 
 	if task:
 		conditions.append("t.name = %(task)s")

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
@@ -15,10 +15,12 @@ def get_task(status=None, task=None, project=None, customer=None, department=Non
 	values = {}
 
 	if status:
-		conditions.append("t.status = %(status)s")
-		values["status"] = status
-	else:
-		conditions.append("t.status IN ('open', 'working', 'overdue')")
+		if status in ["completed", "cancelled"]:
+			return
+		else:
+			proper_status = status.replace("_", " ").title()
+			conditions.append("t.status = %(status)s")
+			values["status"] = proper_status
 
 	if task:
 		conditions.append("t.name = %(task)s")


### PR DESCRIPTION
## Feature description
The Task Management Tool now correctly filters tasks based on the selected status. When a specific status such as “Pending Review” is selected, only tasks with that status are displayed. If the status selected is “Completed” or “Cancelled”, no tasks are filtered. When no status is selected, all tasks are shown.

Additionally, task statuses such as Pending Review and Hold now display the status update (check) icon along with proper color coding. The UI coloring logic was also fixed to support status values with spaces.
Remove options 'Completed and Cancelled from status options in Task Management tool UI
## Analysis and design (optional)
The filtering logic was updated to handle task statuses properly, including converting input status to match the format used in the Task DocType. Tasks with certain statuses are conditionally filtered or displayed based on the selected value.
The Task Management UI was also updated to:
  - support color mapping for additional statuses (Pending Review, Hold),
  - correctly apply colors for statuses with spaces,
  - show status update icons for these additional statuses.

## Solution description
Backend Changes(Python)
- Updated the get_task server-side function to properly filter tasks based on the selected status.
- Added logic to convert input status (snake_case) to proper format.
- Prevent filtering when Completed or Cancelled is selected.
- Ensured that when no status is selected, all tasks are returned except tasks which are 'Completed' and 'Cancelled'.

Frontend Changes (JavaScript)
- Added new color mappings for Pending Review and Hold.
- Fixed object key handling by quoting statuses with spaces.
- Added support for showing the clickable check icon on:
    - Open
    - Overdue
    - Working
    - Pending Review
    - Hold
- Updated the filter options by removing unnecessary statuses.
- Replaced manual refresh logic with refresh_tasks(page) to simplify UX and ensure updated behavior.

## Output screenshots (optional)
**When no status is selected,all tasks are shown**
<img width="1648" height="931" alt="image" src="https://github.com/user-attachments/assets/6ddce437-7bd9-4cd5-a60c-12a43cacfedb" />
<img width="1648" height="931" alt="image" src="https://github.com/user-attachments/assets/1af2d561-6bf3-47dc-b719-7e42b526fea9" />

**When each of the status selected,tasks with selected status are displayed**
[Uploading Screencast from 11-25-2025 05:09:38 PM.webm…]()

**When the status selected is “Completed” or “Cancelled”, no tasks are filtered.**
<img width="1648" height="931" alt="image" src="https://github.com/user-attachments/assets/47851a02-ba24-407e-888d-f9ad661c7f51" />
<img width="1657" height="797" alt="image" src="https://github.com/user-attachments/assets/8a728466-a44d-483c-be6d-14c3d31d43ab" />

Reorder the status options in dialog 'Update Task Status'
<img width="1492" height="848" alt="image" src="https://github.com/user-attachments/assets/641874aa-c5a1-482a-8263-d44c9cd087e0" />

## Areas affected and ensured
- Task Management Tool page
- get_task Python function
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
