### PR TITLE
fix: Fetch the item description from the Item doctype when creating a  Sales Order

### DIFF
--- a/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
+++ b/one_compliance/one_compliance/doctype/compliance_agreement/compliance_agreement.py
@@ -443,7 +443,6 @@ def create_sales_orders_from_compliance_agreements(posting_date=today()):
 							"item_name": item_name,
 							"qty": 1,
 							"rate": detail.rate or 0,
-							"description": f"Auto-created from Compliance Agreement {agreement.name}"
 						})
 
 						so.insert(ignore_permissions=True)


### PR DESCRIPTION

## Issue description
-  need to fix the when creating the sales order from compliance agreement, item description is fetched as default description 


## Solution description
- fixed when creating sales order from compliance agreement , item description is fetched from the item doctype 


## Output screenshots (optional)
[Screencast from 27-11-25 11:02:48 AM IST.webm](https://github.com/user-attachments/assets/9ab91c20-9699-4489-9f0a-908b87729a93)


## Areas affected and ensured
sales order and compliance agreement

## Is there any existing behavior change of other features due to this code change?
No. 
## Was this feature tested on the browsers?

  - Mozilla Firefox
  