### PR TITLE
TASK-2025-02726: highlight currently selected page length button

### DIFF
--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.html
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.html
@@ -89,7 +89,7 @@
 
 	<div id="pagination-container" class="text-center" style="margin-top: 10px;"></div>
 		<div class="btn-group ml-3 page-length-buttons" role="group">
-			<button class="btn btn-sm btn-default page-length-btn active" data-length="20">20</button>
+			<button class="btn btn-sm btn-default page-length-btn" data-length="20">20</button>
 			<button class="btn btn-sm btn-default page-length-btn" data-length="100">100</button>
 			<button class="btn btn-sm btn-default page-length-btn" data-length="500">500</button>
 			<button class="btn btn-sm btn-default page-length-btn" data-length="2500">2500</button>

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
@@ -357,6 +357,8 @@ that allow users to control how many items are shown per page
 */
 
 function setup_page_length_buttons(page) {
+	$(".page-length-btn").removeClass("active");
+	$(`.page-length-btn[data-length="${page.page_length}"]`).addClass("active");
 	$(".page-length-btn").off("click").on("click", function () {
 		$(".page-length-btn").removeClass("active");
 		$(this).addClass("active");


### PR DESCRIPTION
## Feature description
Highlight the currently selected page length button on the Task Management Tool page. Users can clearly see which page length (20, 100, 500, 2500) is currently active.
## Analysis and design (optional)
solution involves updating the HTML and JavaScript to dynamically apply the active class to the selected page length button.
## Solution description
- Removed the default active class from the HTML to allow dynamic highlighting.
- Updated setup_page_length_buttons function in task_management_tool.js to:
  - Remove active class from all buttons.
  - Add active class to the button matching the current page.page_length.
- Ensures the correct button is highlighted on page load and after any page refresh.
 ## Output screenshots (optional)
**The following output screenshots shows page length 100, 500 is currently active.**
<img width="1495" height="935" alt="image" src="https://github.com/user-attachments/assets/818e7dca-af15-4990-b75b-cd1a8ab3d45b" />
<img width="1495" height="935" alt="image" src="https://github.com/user-attachments/assets/b7945018-4e8d-4992-860b-9ec58c053d3e" />


## Areas affected and ensured
- Task Management Tool page (task_management_tool.html and task_management_tool.js)
- Pagination and page length selection functionality

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
