### PR TITLE
TASK-2025-02783 : Remove template task from task management tool

### DIFF
--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.js
@@ -1044,7 +1044,7 @@ function update_task_status(page, task_name, project_name, status) {
 		args: { task: task_name, project: project_name, status },
 		callback(r) {
 			if (r.message === "success") {
-				page.fields_dict.status.set_value("working");
+                refresh_tasks(page); 
 			} else {
 				console.warn("Failed to update task status");
 			}

--- a/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
+++ b/one_compliance/one_compliance/page/task_management_tool/task_management_tool.py
@@ -16,14 +16,14 @@ def get_task(status=None, task=None, project=None, customer=None, department=Non
 	values = {}
 
 	if status:
-		if status in ["completed", "cancelled"]:
+		if status in ["completed", "cancelled", "Template"]:
 			return
 		else:
 			proper_status = status.replace("_", " ").title()
 			conditions.append("t.status = %(status)s")
 			values["status"] = proper_status
 	else:
-		conditions.append("t.status NOT IN ('Completed', 'Cancelled')")
+		conditions.append("t.status NOT IN ('Completed', 'Cancelled', 'Template')")
 
 	if task:
 		conditions.append("t.name = %(task)s")


### PR DESCRIPTION
## Feature description
- When updating status of the "Task" as "working",  clear the status filter is also setting as "Working".
 - Remove Template Task  from "Task Management Tool".

## Solution description
- When updating status of the "Task" as "working",  cleared the status filter is also setting as "Working".
 - Removed Template Task  from "Task Management Tool".

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome
