### PR TITLE
TASK-2025-01669 : Connect SO and Project Status

### DIFF
--- a/one_compliance/custom/property_setter/project.py
+++ b/one_compliance/custom/property_setter/project.py
@@ -80,6 +80,14 @@ def get_project_property_setters():
 			"field_name": "status",
 			"property": "options",
 			"property_type": "Text",
-			"value": "Open\nInvoiced\nPaid\nHold\nOverdue\nCompleted\nCancelled",
+			"value": "Open\nInvoiced\nPaid\nPartially Paid\nHold\nOverdue\nCompleted\nCancelled",
+		},
+		{
+			"doc_type": "Project",
+			"doctype_or_field": "DocField",
+			"field_name": "status",
+			"property": "read_only",
+			"property_type": "Check",
+			"value": "1",
 		},
 	]

--- a/one_compliance/one_compliance/doc_events/payment_entry.py
+++ b/one_compliance/one_compliance/doc_events/payment_entry.py
@@ -2,28 +2,34 @@ import frappe
 
 
 def payment_entry_on_submit(doc, method):
-	"""method sets workflow for Sales Order if the Payment Entry is referenced to an SI against it"""
+    """Sets workflow for Sales Order based on Sales Invoice updated status"""
 
-	for payment_reference in doc.references:
+    for ref in doc.references:
 
-		if payment_reference.reference_doctype == "Sales Invoice":
+        if ref.reference_doctype == "Sales Invoice":
 
-			sales_order = frappe.db.get_value(
-				"Sales Invoice Item",
-				{"parent": payment_reference.reference_name},
-				"sales_order",
-			)
+            si = frappe.get_doc("Sales Invoice", ref.reference_name)
 
-			if payment_reference.outstanding_amount == 0:
-				new_state = "Paid"
-				project_status = "Paid"
-			elif payment_reference.allocated_amount < payment_reference.outstanding_amount:
-					new_state = "Partially Paid"
-					project_status = "Partially Paid" 
-			else:
-				continue
-			
-			frappe.db.set_value("Sales Order", sales_order, "workflow_state", new_state)
-			project = frappe.db.get_value("Sales Order", sales_order, "project")
-			if project:
-				frappe.db.set_value("Project", project, "status", project_status)
+            sales_order = frappe.db.get_value(
+                "Sales Invoice Item",
+                {"parent": si.name},
+                "sales_order",
+            )
+
+            outstanding = si.outstanding_amount
+            grand_total = si.rounded_total or si.grand_total
+
+            if outstanding == 0:
+                new_state = "Paid"
+                project_status = "Paid"
+
+            elif outstanding < grand_total:
+                new_state = "Partially Paid"
+                project_status = "Partially Paid"
+
+            else:
+                continue
+            frappe.db.set_value("Sales Order", sales_order, "workflow_state", new_state)
+            project = frappe.db.get_value("Sales Order", sales_order, "project")
+            if project:
+                frappe.db.set_value("Project", project, "status", project_status)

--- a/one_compliance/one_compliance/doc_events/payment_entry.py
+++ b/one_compliance/one_compliance/doc_events/payment_entry.py
@@ -16,9 +16,14 @@ def payment_entry_on_submit(doc, method):
 
 			if payment_reference.outstanding_amount == 0:
 				new_state = "Paid"
+				project_status = "Paid"
 			elif payment_reference.allocated_amount < payment_reference.outstanding_amount:
 					new_state = "Partially Paid"
+					project_status = "Partially Paid" 
 			else:
 				continue
 			
 			frappe.db.set_value("Sales Order", sales_order, "workflow_state", new_state)
+			project = frappe.db.get_value("Sales Order", sales_order, "project")
+			if project:
+				frappe.db.set_value("Project", project, "status", project_status)

--- a/one_compliance/one_compliance/doc_events/project.py
+++ b/one_compliance/one_compliance/doc_events/project.py
@@ -58,6 +58,11 @@ def set_project_status(project, status, comment=None):
 
 	project = frappe.get_doc("Project", project)
 	frappe.has_permission(doc=project, throw=True)
+	if status == "Cancelled" and project.sales_order:
+		if frappe.db.exists("Sales Order", project.sales_order):
+			so = frappe.get_doc("Sales Order", project.sales_order)
+			if so.docstatus == 1:
+				so.cancel()
 
 	tasks = frappe.get_all("Task", filters={"project": project.name}, fields=["name", "status"])
 
@@ -211,3 +216,4 @@ def create_tasks_from_template(project):
 		created_tasks.append(task.name)
 
 	return created_tasks
+	

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -409,6 +409,8 @@ def create_sales_order_from_event(event, customer=None, sub_category=None, rate=
 def so_on_cancel_custom(doc, method=None):
 	"""Set workflow state to Cancelled when cancelling sales order"""
 	doc.db_set("workflow_state", "Cancelled")
+	if doc.project:
+		frappe.db.set_value("Project", doc.project, "status", "Cancelled")
 
 def so_on_update_after_submit(doc, method):
 	'''


### PR DESCRIPTION
## Feature description
- Add partially paid option in status field of project.
- when a sales order is cancelled,the linked project must also be cancelled.
- when a sales order is partially paid,the linked project's status must update to reflect partially paid.

## Solution description
- Added partially paid option in status field of project.
- Set readonly to status of project.
- when a sales order is cancelled,the linked project must also be cancelled.
- when a project is cancelled,the linked sales order must also be cancelled.
- when a sales order is partially paid,the linked project's status must update to reflect partially paid.
- when a sales order is paid,the linked project's status must update to reflect paid.

## Output screenshots (optional)


## Is there any existing behavior change of other features due to this code change?
No.
## Was this feature tested on the browsers?
  - Chrome
