### PR TITLE
feat: create purchase invoice from sales order

### DIFF
--- a/one_compliance/custom/custom_field/project.py
+++ b/one_compliance/custom/custom_field/project.py
@@ -128,5 +128,18 @@ def get_project_custom_fields():
 				"read_only": 1,
 				"insert_after": "custom_is_internal",
 			},
+			{
+				"fieldname": "project_dashboard_html",
+				"fieldtype": "HTML",
+				"label": "",
+				"insert_before": "naming_series"
+			},
+			{
+				"fieldname": "project_dashboard_section",
+				"fieldtype": "Section Break",
+				"label": " ",
+				"insert_after": "project_dashboard_html"
+			}
+
 		]
 	}

--- a/one_compliance/custom/custom_field/project.py
+++ b/one_compliance/custom/custom_field/project.py
@@ -140,6 +140,5 @@ def get_project_custom_fields():
 				"label": " ",
 				"insert_after": "project_dashboard_html"
 			}
-
 		]
 	}

--- a/one_compliance/custom/custom_field/purchase_invoice.py
+++ b/one_compliance/custom/custom_field/purchase_invoice.py
@@ -1,0 +1,18 @@
+def get_purchase_invoice_custom_fields():
+	'''
+		Method to get custom fields for Purchase Invoice doctype
+	'''
+	return {
+		"Purchase Invoice": [
+			{
+				"fieldname": "sales_order",
+				"fieldtype": "Link",
+				"label": "Sales Order",
+				"insert_after": "project",
+				"options": "Sales Order",
+				"read_only": 1,
+			}
+		]		
+	}
+  
+

--- a/one_compliance/custom/custom_field/sales_order.py
+++ b/one_compliance/custom/custom_field/sales_order.py
@@ -195,8 +195,15 @@ def get_sales_order_custom_fields():
 				"read_only": 1,
 				"depends_on": "eval: doc.is_outsource_service",
 				"fetch_from": "purchase_invoice.status"
-			}
-
+			},
+			{
+				"fieldname": "outstanding_amount",
+				"fieldtype": "Currency",
+				"label": "Outstanding Amount",
+				"fetch_from": "purchase_invoice.outstanding_amount",
+				"read_only": 1,
+				"insert_after": "payment_status",
+    		}
 
 		]
 	}

--- a/one_compliance/custom/custom_field/sales_order.py
+++ b/one_compliance/custom/custom_field/sales_order.py
@@ -176,7 +176,8 @@ def get_sales_order_custom_fields():
 				"options": "Supplier",
 				"insert_after": "custom_billing_date",
 				"allow_on_submit": 1,
-				"depends_on": "eval: doc.is_outsource_service"
+				"depends_on": "eval: doc.is_outsource_service",
+				"mandatory_depends_on": "eval: doc.is_outsource_service"
 			},
 			{
 				"fieldname": "purchase_invoice",

--- a/one_compliance/custom/custom_field/sales_order.py
+++ b/one_compliance/custom/custom_field/sales_order.py
@@ -162,5 +162,41 @@ def get_sales_order_custom_fields():
 				"label": "Is Premium Project",
 				"insert_after": "amended_from"
 			},
+			{
+				"fieldname": "is_outsource_service",
+				"fieldtype": "Check",
+				"label": "Is Outsource Service",
+				"insert_after": "is_premium_project",
+				"allow_on_submit": 1
+			},
+			{
+				"fieldname": "supplier",
+				"fieldtype": "Link",
+				"label": "Supplier",
+				"options": "Supplier",
+				"insert_after": "custom_billing_date",
+				"allow_on_submit": 1,
+				"depends_on": "eval: doc.is_outsource_service"
+			},
+			{
+				"fieldname": "purchase_invoice",
+				"fieldtype": "Link",
+				"label": "Purchase Invoice",
+				"options": "Purchase Invoice",
+				"insert_after": "supplier",
+				"allow_on_submit": 1,
+				"depends_on": "eval: doc.is_outsource_service"
+			},
+			{
+				"fieldname": "payment_status",
+				"fieldtype": "Data",
+				"label": "Payment Status",
+				"insert_after": "purchase_invoice",
+				"read_only": 1,
+				"depends_on": "eval: doc.is_outsource_service",
+				"fetch_from": "purchase_invoice.status"
+			}
+
+
 		]
 	}

--- a/one_compliance/custom/custom_field/sales_order.py
+++ b/one_compliance/custom/custom_field/sales_order.py
@@ -204,6 +204,5 @@ def get_sales_order_custom_fields():
 				"read_only": 1,
 				"insert_after": "payment_status",
     		}
-
 		]
 	}

--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -184,7 +184,7 @@ doc_events = {
 		'on_update': 'one_compliance.one_compliance.doc_events.timesheet.check_lag_and_notify',
 	},
 	"Purchase Invoice": {
-		"on_update": "one_compliance.one_compliance.doc_events.purchase_invoice.update_sales_order"
+		"on_update": "one_compliance.one_compliance.doc_events.purchase_invoice.update_sales_order",
 	}
 }	
 

--- a/one_compliance/hooks.py
+++ b/one_compliance/hooks.py
@@ -182,6 +182,9 @@ doc_events = {
     },
 	'Timesheet': {
 		'on_update': 'one_compliance.one_compliance.doc_events.timesheet.check_lag_and_notify',
+	},
+	"Purchase Invoice": {
+		"on_update": "one_compliance.one_compliance.doc_events.purchase_invoice.update_sales_order"
 	}
 }	
 

--- a/one_compliance/one_compliance/doc_events/project.py
+++ b/one_compliance/one_compliance/doc_events/project.py
@@ -217,3 +217,20 @@ def create_tasks_from_template(project):
 
 	return created_tasks
 	
+
+
+@frappe.whitelist()
+def get_project_tasks(project):
+    tasks = frappe.get_all(
+        "Task",
+        filters={"project": project},
+        fields=["name", "subject", "status"],
+        order_by="modified desc"
+    )
+
+    has_completed = any(t.status == "Completed" for t in tasks)
+
+    return {
+        "show": has_completed,
+        "tasks": tasks
+    }

--- a/one_compliance/one_compliance/doc_events/project.py
+++ b/one_compliance/one_compliance/doc_events/project.py
@@ -216,11 +216,13 @@ def create_tasks_from_template(project):
 		created_tasks.append(task.name)
 
 	return created_tasks
-	
 
 
 @frappe.whitelist()
 def get_project_tasks(project):
+    """ 
+    Fetch tasks related to a project and determine if any are completed.
+    """
     tasks = frappe.get_all(
         "Task",
         filters={"project": project},

--- a/one_compliance/one_compliance/doc_events/purchase_invoice.py
+++ b/one_compliance/one_compliance/doc_events/purchase_invoice.py
@@ -5,7 +5,6 @@ def update_sales_order(doc, method):
     """
 	Update linked Sales Order's payment status and outstanding amount
 	"""
-
     frappe.db.set_value(
         "Sales Order",
         doc.sales_order,

--- a/one_compliance/one_compliance/doc_events/purchase_invoice.py
+++ b/one_compliance/one_compliance/doc_events/purchase_invoice.py
@@ -1,0 +1,17 @@
+import frappe
+
+
+def update_sales_order(doc, method):
+    """
+	Update linked Sales Order's payment status and outstanding amount
+	"""
+
+    frappe.db.set_value(
+        "Sales Order",
+        doc.sales_order,
+        {
+            "payment_status": doc.status,
+            "outstanding_amount": doc.outstanding_amount
+        },
+        update_modified=False
+    )

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -666,6 +666,8 @@ def create_purchase_invoice(docname, items):
 
     so = frappe.get_doc("Sales Order", docname)
 
+    project_id = frappe.db.get_value("Project", {"sales_order": docname}, "name") or None
+
     if not so.supplier:
         frappe.throw(_("Supplier is required in Sales Order"))
 
@@ -674,6 +676,7 @@ def create_purchase_invoice(docname, items):
         "supplier": so.supplier,
         "company": so.company,
         "posting_date": today(),
+        "project": project_id,
         "items": []
     })
 

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -677,6 +677,7 @@ def create_purchase_invoice(docname, items):
         "company": so.company,
         "posting_date": today(),
         "project": project_id,
+        "sales_order": so.name,
         "items": []
     })
 

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -2,9 +2,10 @@ from datetime import datetime, timedelta
 
 import frappe
 from frappe import _
-from frappe.utils import add_days, add_months, date_diff, getdate, json, today
+from frappe.utils import add_days, add_months, date_diff, getdate, json, today, flt
 from one_compliance.one_compliance.utils import add_custom as add_assign
 from one_compliance.one_compliance.utils import create_todo, get_users_with_role
+
 
 
 @frappe.whitelist()
@@ -653,3 +654,37 @@ def set_compliance_fields(doc, method):
 			if subcat:
 				item.custom_compliance_category     = subcat.compliance_category
 				item.custom_compliance_subcategory  = subcat.name
+
+
+
+@frappe.whitelist()
+def create_purchase_invoice(docname, items):
+    """Create Purchase Invoice from Sales Order"""
+
+    if isinstance(items, str):
+        items = json.loads(items)
+
+    so = frappe.get_doc("Sales Order", docname)
+
+    if not so.supplier:
+        frappe.throw(_("Supplier is required in Sales Order"))
+
+    pi = frappe.get_doc({
+        "doctype": "Purchase Invoice",
+        "supplier": so.supplier,
+        "company": so.company,
+        "posting_date": today(),
+        "items": []
+    })
+
+    # Add items
+    for item in items:
+        pi.append("items", {
+            "item_code": item.get("item_code"),
+            "qty": flt(item.get("qty", 1)),
+            "rate": flt(item.get("rate", 0))
+        })
+
+    pi.insert()
+
+    return pi.name

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -655,8 +655,6 @@ def set_compliance_fields(doc, method):
 				item.custom_compliance_category     = subcat.compliance_category
 				item.custom_compliance_subcategory  = subcat.name
 
-
-
 @frappe.whitelist()
 def create_purchase_invoice(docname, items):
     """Create Purchase Invoice from Sales Order"""

--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -685,6 +685,8 @@ def create_purchase_invoice(docname, items):
             "rate": flt(item.get("rate", 0))
         })
 
-    pi.insert()
+    pi.insert(ignore_permissions=True)
+
+    so.db_set("purchase_invoice", pi.name, update_modified=False)
 
     return pi.name

--- a/one_compliance/public/js/project.js
+++ b/one_compliance/public/js/project.js
@@ -287,7 +287,7 @@ function load_project_tasks(frm) {
             project: frm.doc.name
         },
         callback: function (r) {
-            if (!r.message || !r.message.show) {
+            if (!r.message) {
                 frm.set_df_property('project_dashboard_html', 'options', '');
                 return;
             }

--- a/one_compliance/public/js/project.js
+++ b/one_compliance/public/js/project.js
@@ -95,6 +95,8 @@ frappe.ui.form.on('Project', {
 			}
 		});
 	}
+
+    load_project_tasks(frm);
 	},
 });
 
@@ -269,3 +271,84 @@ let customer_documents = function (frm) {
 	});
 	d.show();
 };
+
+
+
+
+
+
+function load_project_tasks(frm) {
+    frappe.call({
+        method: 'one_compliance.one_compliance.doc_events.project.get_project_tasks',
+        args: {
+            project: frm.doc.name
+        },
+        callback: function (r) {
+            if (!r.message || !r.message.show) {
+                frm.set_df_property('project_dashboard_html', 'options', '');
+                return;
+            }
+
+            let html = `
+                <div class="project-task-dashboard">
+                    <h5 style="margin-bottom: 8px;">Task Status</h5>
+
+                    <div class="task-table-wrapper">
+                        <table class="table table-bordered table-sm" style="width: 100%; margin-bottom: 0;">
+                            <thead>
+                                <tr>
+                                    <th style="width: 25%">Task ID</th>
+                                    <th style="width: 50%">Subject</th>
+                                    <th style="width: 25%">Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+            `;
+
+            r.message.tasks.forEach(task => {
+                html += `
+                    <tr>
+                        <td>
+                            <a href="/app/task/${task.name}" target="_blank">
+                                ${task.name}
+                            </a>
+                        </td>
+                        <td>${task.subject || ''}</td>
+                        <td>
+                            <span class="indicator ${
+                                task.status === 'Completed' ? 'green' : 'blue'
+                            }">
+                                ${task.status}
+                            </span>
+                        </td>
+                    </tr>
+                `;
+            });
+
+            html += `
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <style>
+                    .task-table-wrapper {
+                        max-height: 300px;
+                        overflow-y: auto;    /* 🔹 SCROLL */
+                        border: 1px solid var(--border-color);
+                        border-radius: 6px;
+                    }
+
+                    .task-table-wrapper thead th {
+                        position: sticky;
+                        top: 0;
+                        background: var(--card-bg);
+                        z-index: 1;
+                    }
+                </style>
+            `;
+
+            frm.set_df_property('project_dashboard_html', 'options', html);
+        }
+    });
+}

--- a/one_compliance/public/js/project.js
+++ b/one_compliance/public/js/project.js
@@ -1,4 +1,9 @@
 frappe.ui.form.on('Project', {
+
+    onload(frm) {
+        load_project_tasks(frm);
+    },
+
 	refresh(frm) {
 	if (!frm.is_new()) {
 		setTimeout(() => {

--- a/one_compliance/public/js/project.js
+++ b/one_compliance/public/js/project.js
@@ -278,10 +278,6 @@ let customer_documents = function (frm) {
 };
 
 
-
-
-
-
 function load_project_tasks(frm) {
     frappe.call({
         method: 'one_compliance.one_compliance.doc_events.project.get_project_tasks',

--- a/one_compliance/public/js/project.js
+++ b/one_compliance/public/js/project.js
@@ -277,7 +277,9 @@ let customer_documents = function (frm) {
 	d.show();
 };
 
-
+/**
+ * Load Project Tasks and display in HTML field
+ */
 function load_project_tasks(frm) {
     frappe.call({
         method: 'one_compliance.one_compliance.doc_events.project.get_project_tasks',

--- a/one_compliance/public/js/sales_order.js
+++ b/one_compliance/public/js/sales_order.js
@@ -285,9 +285,6 @@ const apply_filter_to_supplier_purchase_invoice = (frm, supplier) => {
 }
 
 
-
-
-
 function create_purchase_invoice(frm) {
 	// Prompt user to add Service Item(s) and Rate(s)
 	frappe.prompt([

--- a/one_compliance/public/js/sales_order.js
+++ b/one_compliance/public/js/sales_order.js
@@ -33,7 +33,7 @@ frappe.ui.form.on('Sales Order', {
         handle_rework_order(frm);
 
         // Show button only if checkbox is checked and no PI exists yet
-		if (frm.doc.is_outsource_service && !frm.doc.purchase_invoice) {
+		if (frm.doc.docstatus === 1 && frm.doc.is_outsource_service && !frm.doc.purchase_invoice) {
 			frm.add_custom_button(__('Create Purchase Invoice'), () => {
 				create_purchase_invoice(frm);
 			});

--- a/one_compliance/public/js/sales_order.js
+++ b/one_compliance/public/js/sales_order.js
@@ -269,7 +269,7 @@ function handle_rework_order(frm) {
 }
 
 
-
+// Get list of Projects linked to the given Sales Order
 const get_projects_from_sales_order = async (sales_order) => {
     const r = await frappe.call({
         method: "frappe.client.get_list",
@@ -293,7 +293,6 @@ const apply_filter_to_supplier_purchase_invoice = async (frm, supplier) => {
     if (!frm.doc.name || !supplier) return;
 
     const projects = await get_projects_from_sales_order(frm.doc.name);
-    console.log(projects, "project test ok");
 
     frm.set_query("purchase_invoice", () => {
         // Supplier-only filter
@@ -366,6 +365,7 @@ function create_purchase_invoice(frm) {
 }
 
 
+// Make 'is_outsource_service' field read-only if Purchase Invoice is linked
 const make_is_outsource_service_read_only = (frm) => {
     if (frm.doc.purchase_invoice) {
         frm.set_df_property("is_outsource_service", "read_only", true);

--- a/one_compliance/public/js/sales_order.js
+++ b/one_compliance/public/js/sales_order.js
@@ -301,7 +301,8 @@ function create_purchase_invoice(frm) {
                 return {
                     filters: {
                         is_purchase_item: 1,
-                        is_service_item: 1
+                        is_service_item: 1,
+                        is_stock_item: 0
                     }
                 }
             }

--- a/one_compliance/public/js/sales_order.js
+++ b/one_compliance/public/js/sales_order.js
@@ -39,6 +39,13 @@ frappe.ui.form.on('Sales Order', {
 			});
 		}
     },
+
+    is_outsource_service : (frm) => {
+            if (frm.doc.is_outsource_service) {
+                frm.set_df_property('supplier', 'reqd', true);
+            }
+        },
+
     supplier: (frm) => {
         frm.set_value("purchase_invoice", null);
         apply_filter_to_supplier_purchase_invoice(frm, frm.doc.supplier);
@@ -289,7 +296,15 @@ function create_purchase_invoice(frm) {
 			fieldtype: 'Link',
 			label: 'Service Item',
 			options: 'Item',
-			reqd: 1
+			reqd: 1,
+            get_query: () => {
+                return {
+                    filters: {
+                        is_purchase_item: 1,
+                        is_service_item: 1
+                    }
+                }
+            }
 		},
 		{
 			fieldname: 'rate',
@@ -309,6 +324,7 @@ function create_purchase_invoice(frm) {
 				if (r.message) {
 					frm.set_value('purchase_invoice', r.message);
 					frm.refresh_field('purchase_invoice');
+                    frm.reload_doc();
 					frappe.msgprint(__('Purchase Invoice {0} created successfully', [r.message]));
 				}
 			}

--- a/one_compliance/public/js/sales_order.js
+++ b/one_compliance/public/js/sales_order.js
@@ -40,15 +40,13 @@ frappe.ui.form.on('Sales Order', {
 		}
     },
 
-    is_outsource_service : (frm) => {
-            if (frm.doc.is_outsource_service) {
-                frm.set_df_property('supplier', 'reqd', true);
-            }
-        },
-
     supplier: (frm) => {
         frm.set_value("purchase_invoice", null);
         apply_filter_to_supplier_purchase_invoice(frm, frm.doc.supplier);
+    },
+
+    purchase_invoice: (frm) => {
+        make_is_outsource_service_read_only(frm);
     }
 });
 
@@ -271,18 +269,52 @@ function handle_rework_order(frm) {
 }
 
 
+
+const get_projects_from_sales_order = async (sales_order) => {
+    const r = await frappe.call({
+        method: "frappe.client.get_list",
+        args: {
+            doctype: "Project",
+            filters: {
+                sales_order: sales_order
+            },
+            fields: ["name"]
+        }
+    });
+
+    return (r.message || []).map(p => p.name);
+};
+
+
 /**
- * Apply filter to Purchase Invoice field based on selected Supplier
+ * Apply filter to Purchase Invoice field based on Supplier and linked Projects
  */
-const apply_filter_to_supplier_purchase_invoice = (frm, supplier) => {
-    frm.set_query("purchase_invoice", ()=> {
+const apply_filter_to_supplier_purchase_invoice = async (frm, supplier) => {
+    if (!frm.doc.name || !supplier) return;
+
+    const projects = await get_projects_from_sales_order(frm.doc.name);
+    console.log(projects, "project test ok");
+
+    frm.set_query("purchase_invoice", () => {
+        // Supplier-only filter
+        if (!projects || !projects.length) {
+            return {
+                filters: {
+                    supplier: supplier
+                }
+            };
+        }
+        // Supplier + Projects filter
         return {
             filters: {
                 supplier: supplier,
+                project: ["in", projects]
             }
-        }
-    })
-}
+        };
+    });
+};
+
+
 
 
 function create_purchase_invoice(frm) {
@@ -331,4 +363,14 @@ function create_purchase_invoice(frm) {
 	'Add Service Item',
 	'Create'
 	);
+}
+
+
+const make_is_outsource_service_read_only = (frm) => {
+    if (frm.doc.purchase_invoice) {
+        frm.set_df_property("is_outsource_service", "read_only", true);
+    }
+    else {
+        frm.set_df_property("is_outsource_service", "read_only", false);
+    }
 }

--- a/one_compliance/public/js/sales_order.js
+++ b/one_compliance/public/js/sales_order.js
@@ -31,6 +31,17 @@ frappe.ui.form.on('Sales Order', {
         handle_unlinking(frm);
 
         handle_rework_order(frm);
+
+        // Show button only if checkbox is checked and no PI exists yet
+		if (frm.doc.is_outsource_service && !frm.doc.purchase_invoice) {
+			frm.add_custom_button(__('Create Purchase Invoice'), () => {
+				create_purchase_invoice(frm);
+			});
+		}
+    },
+    supplier: (frm) => {
+        frm.set_value("purchase_invoice", null);
+        apply_filter_to_supplier_purchase_invoice(frm, frm.doc.supplier);
     }
 });
 
@@ -250,4 +261,60 @@ function handle_rework_order(frm) {
       frm.remove_custom_button("Payment Request", "Create");
     }, 500);
   }
+}
+
+
+/**
+ * Apply filter to Purchase Invoice field based on selected Supplier
+ */
+const apply_filter_to_supplier_purchase_invoice = (frm, supplier) => {
+    frm.set_query("purchase_invoice", ()=> {
+        return {
+            filters: {
+                supplier: supplier,
+            }
+        }
+    })
+}
+
+
+
+
+
+function create_purchase_invoice(frm) {
+	// Prompt user to add Service Item(s) and Rate(s)
+	frappe.prompt([
+		{
+			fieldname: 'item_code',
+			fieldtype: 'Link',
+			label: 'Service Item',
+			options: 'Item',
+			reqd: 1
+		},
+		{
+			fieldname: 'rate',
+			fieldtype: 'Currency',
+			label: 'Rate',
+			reqd: 1
+		}
+	],
+	(values) => {
+		frappe.call({
+			method: 'one_compliance.one_compliance.doc_events.sales_order.create_purchase_invoice',
+			args: {
+				docname: frm.doc.name,
+				items: [values]
+			},
+			callback: function(r) {
+				if (r.message) {
+					frm.set_value('purchase_invoice', r.message);
+					frm.refresh_field('purchase_invoice');
+					frappe.msgprint(__('Purchase Invoice {0} created successfully', [r.message]));
+				}
+			}
+		});
+	},
+	'Add Service Item',
+	'Create'
+	);
 }

--- a/one_compliance/setup.py
+++ b/one_compliance/setup.py
@@ -21,6 +21,7 @@ from one_compliance.custom.custom_field.todo import get_todo_custom_fields
 from one_compliance.custom.custom_field.opportunity_item import get_opportunity_item_custom_fields
 from one_compliance.custom.custom_field.compliance_sub_category import get_compliance_sub_category_custom_fields
 from one_compliance.custom.custom_field.timesheet_detail import get_timesheet_detail_custom_fields
+from one_compliance.custom.custom_field.purchase_invoice import get_purchase_invoice_custom_fields
 
 # Custom property setter method imports
 from one_compliance.custom.property_setter.contact_email import get_contact_email_property_setters
@@ -146,6 +147,7 @@ def get_custom_fields():
 	custom_fields.update(get_opportunity_item_custom_fields())
 	custom_fields.update(get_compliance_sub_category_custom_fields())
 	custom_fields.update(get_timesheet_detail_custom_fields())
+	custom_fields.update(get_purchase_invoice_custom_fields())
 	custom_fields.update(())
 	return custom_fields
 


### PR DESCRIPTION
## Feature description
Add a submit-time option to mark Outsource Service on Sales Order.
Enable Supplier selection only when Outsource Service is checked.
Provide a button to create Purchase Invoice (with service item & rate), visible only when enabled, and auto-link it back.
Make Payment Status read-only and auto-updated based on linked Purchase Invoice status.

Completed Task View in Project:
If at least one task is completed:-
The status of all tasks must be visible below the connections section in project form
Task ID, Subject and status should be visible


## Solution description
Introduced a submit-allowed checkbox Outsource Service on Sales Order to control outsourcing flow. Enabled Supplier selection only when the option is checked and added a conditional Create Purchase Invoice button, allowing users to add service item and rate. Implemented logic to auto-create and link the Purchase Invoice to the Sales Order, and set Payment Status as read-only, dynamically updating it based on the linked Purchase Invoice status.

## Output screenshots (optional)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6671a2c6-87d3-44df-b452-6b838ec56281" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/21f90b28-a9eb-4cfb-8fc0-582d4c094135" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/db7844f2-f121-4e74-8b27-fb08ab9d8fe0" />



## Was this feature tested on these browsers?
- [ ]   Chrome

