### PR TITLE
TASK-2026-00155 : Patch for setting mode of payment and payable amount

### DIFF
--- a/one_compliance/custom/property_setter/task.py
+++ b/one_compliance/custom/property_setter/task.py
@@ -128,4 +128,20 @@ def get_task_property_setters():
 			"property_type": "Data",
 			"value": "",
 		},
+		{
+			"doc_type": "Task",
+			"doctype_or_field": "DocField",
+			"field_name": "custom_mode_of_payment",
+			"property": "mandatory_depends_on",
+			"property_type": "Data",
+			"value": "",
+		},
+		{
+			"doc_type": "Task",
+			"doctype_or_field": "DocField",
+			"field_name": "custom_payable_amount",
+			"property": "mandatory_depends_on",
+			"property_type": "Data",
+			"value": "",
+		},
 	]

--- a/one_compliance/patches.txt
+++ b/one_compliance/patches.txt
@@ -4,3 +4,4 @@
 [post_model_sync]
 # These patches will run post doctype sync
 one_compliance.patches.v15.so_workflow_cancel_state 2024-08-28test1
+one_compliance.patches.v15.task_payment_table 2026-01-29test1

--- a/one_compliance/patches/v15/task_payment_table.py
+++ b/one_compliance/patches/v15/task_payment_table.py
@@ -1,0 +1,47 @@
+import frappe
+
+def execute():
+	tasks = frappe.get_all(
+		"Task",
+		filters={
+			"custom_payable_amount": [">", 0],
+			"custom_mode_of_payment": ["!=", ""]
+		},
+		fields=[
+			"name",
+			"custom_payable_amount",
+			"custom_mode_of_payment",
+			"custom_reference_number",
+			"custom_reference_date"
+		]
+	)
+
+	for task in tasks:
+		if not task.custom_payable_amount:
+			continue
+		exists = frappe.db.exists(
+			"Task Payment Information",
+			{
+				"parent": task.name,
+				"parenttype": "Task",
+				"parentfield": "custom_task_payment_informations",
+				"mode_of_payment": task.custom_mode_of_payment,
+				"payable_amount": task.custom_payable_amount
+			}
+		)
+
+		if exists:
+			continue
+
+		frappe.get_doc({
+			"doctype": "Task Payment Information",
+			"parent": task.name,
+			"parenttype": "Task",
+			"parentfield": "custom_task_payment_informations",
+			"mode_of_payment": task.custom_mode_of_payment,
+			"payable_amount": task.custom_payable_amount,
+			"reference_number": task.custom_reference_number,
+			"reference_date": task.custom_reference_date
+		}).insert(ignore_permissions=True)
+
+	frappe.db.commit()


### PR DESCRIPTION
## Feature description
- Remove mandatory of mode of payment and payable amount in task.
- write patch for setting mode of payment and payable amount in task payment information table of task.

## Solution description
- Removed mandatory of mode of payment and payable amount in task.
- wrote patch for setting mode of payment and payable amount in task payment information table of task.

## Output screenshots (optional)

## Is there any existing behaviour change of other features due to this code change?
No.

## Was this feature tested on these browsers?
- [ ]   Chrome