### PR TITLE
chore:set income account for item

### DIFF
--- a/one_compliance/patches.txt
+++ b/one_compliance/patches.txt
@@ -5,3 +5,4 @@
 # These patches will run post doctype sync
 one_compliance.patches.v15.so_workflow_cancel_state 2024-08-28test1
 one_compliance.patches.v15.task_payment_table 2026-01-29test1
+one_compliance.patches.v15.sync_item_defaults 2026-02-27

--- a/one_compliance/patches/v15/sync_item_defaults.py
+++ b/one_compliance/patches/v15/sync_item_defaults.py
@@ -2,25 +2,22 @@ import frappe
 
 def execute():
 	"""Sync Item Defaults income accounts from Compliance Sub Category."""
-	for sub_cat in frappe.get_all("Compliance Sub Category", filters={"is_billable": 1, "item_code": ["is", "set"]}):
-		doc = frappe.get_doc("Compliance Sub Category", sub_cat.name)
-		item = frappe.get_doc("Item", doc.item_code)
-		mismatch = False
+	for s in frappe.get_all("Compliance Sub Category", filters={"is_billable": 1, "item_code": ["is", "set"]}, fields=["name", "item_code"]):
+		
+		if not frappe.db.exists("Item", s.item_code):
+			continue
 
-		for row in doc.default_account:
-			found = False
-			for d in item.item_defaults:
-				if d.company == row.company:
-					found = True
-					if d.income_account != row.default_income_account:
-						d.income_account = row.default_income_account
-						mismatch = True
-					break
-			if not found:
-				item.append("item_defaults", {"company": row.company, "income_account": row.default_income_account})
-				mismatch = True
+		target = {d.company: d.default_income_account for d in frappe.get_all("Sub Category Account", filters={"parent": s.name}, fields=["company", "default_income_account"])}
+		current = {d.company: d for d in frappe.get_all("Item Default", filters={"parent": s.item_code}, fields=["name", "company", "income_account"])}
 
-		if mismatch:
-			item.flags.ignore_mandatory = True
-			item.flags.ignore_validate = True
-			item.save(ignore_permissions=True)
+		for comp, acc in target.items():
+			if comp in current:
+				if current[comp].income_account != acc:
+					frappe.db.sql("UPDATE `tabItem Default` SET income_account=%s WHERE name=%s", (acc, current[comp].name))
+			else:
+				frappe.db.sql("""
+					INSERT INTO `tabItem Default` (name, parent, parentfield, parenttype, company, income_account, idx)
+					VALUES (%s, %s, 'item_defaults', 'Item', %s, %s, 1)
+				""", (frappe.generate_hash(length=10), s.item_code, comp, acc))
+
+	frappe.clear_cache(doctype="Item")

--- a/one_compliance/patches/v15/sync_item_defaults.py
+++ b/one_compliance/patches/v15/sync_item_defaults.py
@@ -1,0 +1,26 @@
+import frappe
+
+def execute():
+	"""Sync Item Defaults income accounts from Compliance Sub Category."""
+	for sub_cat in frappe.get_all("Compliance Sub Category", filters={"is_billable": 1, "item_code": ["is", "set"]}):
+		doc = frappe.get_doc("Compliance Sub Category", sub_cat.name)
+		item = frappe.get_doc("Item", doc.item_code)
+		mismatch = False
+
+		for row in doc.default_account:
+			found = False
+			for d in item.item_defaults:
+				if d.company == row.company:
+					found = True
+					if d.income_account != row.default_income_account:
+						d.income_account = row.default_income_account
+						mismatch = True
+					break
+			if not found:
+				item.append("item_defaults", {"company": row.company, "income_account": row.default_income_account})
+				mismatch = True
+
+		if mismatch:
+			item.flags.ignore_mandatory = True
+			item.flags.ignore_validate = True
+			item.save(ignore_permissions=True)


### PR DESCRIPTION
## Feature description
Task: TASK-2026-00327
Adds a migration patch to sync the Default Income Account from Compliance Sub Category to the corresponding Item defaults.


## Was this feature tested on these browsers?
- [x]   Chrome

