### PR TITLE
TASK-2026-00393 : Include Draft Journal Entries in Complete Accounts Receivables Report

### DIFF
--- a/one_compliance/one_compliance/report/complete_accounts_receivable_report/complete_accounts_receivable_report.js
+++ b/one_compliance/one_compliance/report/complete_accounts_receivable_report/complete_accounts_receivable_report.js
@@ -34,6 +34,11 @@ frappe.query_reports["Complete Accounts Receivable Report"] = {
             label: __("Customer Group"),
             fieldtype: "Link",
             options: "Customer Group",
+        },
+        {
+            fieldname: "include_draft_journal_entries",
+            label: __("Include Draft Journal Entries"),
+            fieldtype: "Check",
         }
     ]
 };

--- a/one_compliance/one_compliance/report/complete_accounts_receivable_report/complete_accounts_receivable_report.py
+++ b/one_compliance/one_compliance/report/complete_accounts_receivable_report/complete_accounts_receivable_report.py
@@ -115,11 +115,16 @@ def get_data(filters: dict) -> list[dict]:
 def get_journal_entries(filters):
 	"""
 	Returns filtered Journal Entry records linked to customers.
+	Includes Draft Journal Entries if checkbox is enabled.
 	Excludes fully paid Journal Entries.
 	Shows paid amount if partially paid.
 	"""
 	conditions = []
 	vals = []
+	if filters.get("include_draft_journal_entries"):
+		docstatus_condition = "je.docstatus IN (0, 1)"
+	else:
+		docstatus_condition = "je.docstatus = 1"
 
 	if filters.get("company"):
 		conditions.append("je.company = %s")
@@ -175,7 +180,7 @@ def get_journal_entries(filters):
 		LEFT JOIN `tabCustomer` cust
 			ON cust.name = jel.party
 
-		WHERE je.docstatus = 1
+		WHERE {docstatus_condition}
 		  AND jel.party_type = 'Customer'
 		  {where}
 


### PR DESCRIPTION
## Feature description
- Add Filter to Include Draft Journal Entries in Complete Accounts Receivable Report

## Solution description
- Add a checkbox field labeled "Include Draft Journal Entries" in the report filters.
- By default, the checkbox should be unchecked.
- When the checkbox is checked, the report should include Journal Entries with Draft status (docstatus = 0).
- When the checkbox is unchecked, only Submitted Journal Entries (docstatus = 1) should be displayed (current behavior).

## Output screenshots (optional)

## Is there any existing behaviour change of other features due to this code change?
No.

## Was this feature tested on these browsers?
- [ ]   Chrome