### PR TITLE
TASK-2026-00515 : Invoice generation date in sales order

### DIFF
--- a/one_compliance/one_compliance/doc_events/sales_order.py
+++ b/one_compliance/one_compliance/doc_events/sales_order.py
@@ -400,7 +400,7 @@ def create_sales_order_from_event(event, customer=None, sub_category=None, rate=
 	new_sales_order.submit()
 	frappe.db.set_value("Sales Order", new_sales_order.name, "status", "Proforma Invoice")
 	frappe.db.set_value("Sales Order", new_sales_order.name, "workflow_state", "Proforma Invoice")
-	frappe.db.set_value("Sales Order", sales_order, "invoice_generation_date", today())
+	frappe.db.set_value("Sales Order", new_sales_order.name, "invoice_generation_date", today())
 	frappe.msgprint(f"Proforma Invoice {new_sales_order.name} Created against {event}", alert=True)
 	accounts_users = get_users_with_role("Accounts User")
 	add_assign({


### PR DESCRIPTION
## Feature description
While creating a Proforma Invoice from the Event, a Sales Order is generated. However, the invoice_generation_date is being updated on an existing (old) Sales Order of the same customer instead of the newly created Sales Order.

## Solution description
- Updated invoice generation date in newly created service order from event

## Output screenshots (optional)

## Is there any existing behaviour change of other features due to this code change?
No.

## Was this feature tested on these browsers?
- [ ]   Chrome